### PR TITLE
Initialize Electron React scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "calendar-ado",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/main/main.js",
+  "scripts": {
+    "react-start": "react-scripts start",
+    "electron": "ELECTRON_START_URL=http://localhost:3000 electron .",
+    "start": "concurrently \"npm run react-start\" \"npm run electron\"",
+    "build": "react-scripts build",
+    "electron-pack": "electron-builder"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.0",
+    "electron": "^29.0.0",
+    "electron-builder": "^24.0.0",
+    "react-scripts": "5.0.1",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Calendar ADO</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Calendar-Ado</h1>
+      <p>Project setup successful!</p>
+    </div>
+  );
+}
+
+export default App;

--- a/src/hooks/useAdoItems.js
+++ b/src/hooks/useAdoItems.js
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+
+export default function useAdoItems() {
+  const [items, setItems] = useState([]);
+
+  return {
+    items,
+    setItems,
+  };
+}

--- a/src/hooks/useWorkBlocks.js
+++ b/src/hooks/useWorkBlocks.js
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+
+export default function useWorkBlocks() {
+  const [blocks, setBlocks] = useState([]);
+
+  return {
+    blocks,
+    setBlocks,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,0 +1,34 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  if (process.env.ELECTRON_START_URL) {
+    win.loadURL(process.env.ELECTRON_START_URL);
+  } else {
+    win.loadFile(path.join(__dirname, '../../public/index.html'));
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  // expose APIs here when needed
+});

--- a/src/models/workBlock.js
+++ b/src/models/workBlock.js
@@ -1,0 +1,9 @@
+export default class WorkBlock {
+  constructor({ id, start, end, note, workItem }) {
+    this.id = id;
+    this.start = start;
+    this.end = end;
+    this.note = note;
+    this.workItem = workItem;
+  }
+}

--- a/src/models/workItem.js
+++ b/src/models/workItem.js
@@ -1,0 +1,6 @@
+export default class WorkItem {
+  constructor({ id, title }) {
+    this.id = id;
+    this.title = title;
+  }
+}

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -1,0 +1,11 @@
+// Placeholder for Azure DevOps API interactions
+export default class AdoService {
+  constructor(token) {
+    this.token = token;
+  }
+
+  async getWorkItems() {
+    // TODO: implement fetch from Azure DevOps
+    return [];
+  }
+}

--- a/src/services/storageService.js
+++ b/src/services/storageService.js
@@ -1,0 +1,20 @@
+// Placeholder for local storage interactions
+import fs from 'fs';
+import path from 'path';
+
+export default class StorageService {
+  constructor() {
+    this.dataPath = path.join(process.cwd(), 'data.json');
+  }
+
+  read() {
+    if (fs.existsSync(this.dataPath)) {
+      return JSON.parse(fs.readFileSync(this.dataPath));
+    }
+    return { workBlocks: [] };
+  }
+
+  write(data) {
+    fs.writeFileSync(this.dataPath, JSON.stringify(data, null, 2));
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx}', './public/index.html'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- scaffold Electron app with React and Tailwind
- add basic services, models and hooks
- create minimal Electron main process
- configure Tailwind and PostCSS

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684467ea0a088323a0c7c2ef82837d76