### PR TITLE
Add simple MVP with local calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,15 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
    * Tooltips and block styling
    * Area path hint system
    * Theme and tag filter presets
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the application:
+   ```bash
+   npm start
+   ```
+   This will launch both the React dev server and the Electron shell.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,20 @@
 import React from 'react';
+import Calendar from './components/Calendar';
+import TaskList from './components/TaskList';
+import useWorkBlocks from './hooks/useWorkBlocks';
 
 function App() {
+  const { blocks, setBlocks } = useWorkBlocks();
+
+  const addBlock = (block) => {
+    setBlocks([...blocks, block]);
+  };
+
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold">Calendar-Ado</h1>
-      <p>Project setup successful!</p>
+      <h1 className="text-2xl font-bold mb-4">Calendar-Ado MVP</h1>
+      <TaskList />
+      <Calendar blocks={blocks} onAdd={addBlock} />
     </div>
   );
 }

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+
+export default function Calendar({ blocks, onAdd }) {
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const [form, setForm] = useState({ day: 0, start: '09:00', end: '10:00', note: '', workItem: '' });
+
+  const addBlock = (e) => {
+    e.preventDefault();
+    const startDate = new Date();
+    const endDate = new Date();
+    startDate.setDate(startDate.getDate() - startDate.getDay() + 1 + parseInt(form.day));
+    endDate.setDate(startDate.getDate());
+    startDate.setHours(parseInt(form.start.split(':')[0]), parseInt(form.start.split(':')[1]));
+    endDate.setHours(parseInt(form.end.split(':')[0]), parseInt(form.end.split(':')[1]));
+    onAdd({
+      id: Date.now(),
+      start: startDate.toISOString(),
+      end: endDate.toISOString(),
+      note: form.note,
+      workItem: form.workItem,
+    });
+    setForm({ ...form, note: '', workItem: '' });
+  };
+
+  return (
+    <div>
+      <form className="space-x-2 mb-4" onSubmit={addBlock}>
+        <select value={form.day} onChange={(e) => setForm({ ...form, day: e.target.value })}>
+          {days.map((d, idx) => <option key={idx} value={idx}>{d}</option>)}
+        </select>
+        <input type="time" value={form.start} onChange={(e) => setForm({ ...form, start: e.target.value })}/>
+        <input type="time" value={form.end} onChange={(e) => setForm({ ...form, end: e.target.value })}/>
+        <input type="text" placeholder="Work item" value={form.workItem} onChange={(e) => setForm({ ...form, workItem: e.target.value })}/>
+        <input type="text" placeholder="Note" value={form.note} onChange={(e) => setForm({ ...form, note: e.target.value })}/>
+        <button type="submit" className="px-2 py-1 bg-blue-500 text-white">Add</button>
+      </form>
+      <div className="grid grid-cols-7 gap-2">
+        {days.map((day, idx) => (
+          <div key={idx} className="border p-2">
+            <h2 className="font-semibold mb-2">{day}</h2>
+            {blocks.filter(b => {
+              const date = new Date(b.start);
+              return date.getDay() === (idx + 1) % 7;
+            }).map(b => (
+              <div key={b.id} className="mb-2 p-1 bg-gray-200">
+                <div className="text-sm">{new Date(b.start).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})} - {new Date(b.end).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})}</div>
+                <div className="text-xs">{b.workItem} {b.note}</div>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TaskList.jsx
+++ b/src/components/TaskList.jsx
@@ -1,0 +1,23 @@
+import React, { useEffect } from 'react';
+import useAdoItems from '../hooks/useAdoItems';
+import AdoService from '../services/adoService';
+
+export default function TaskList() {
+  const { items, setItems } = useAdoItems();
+
+  useEffect(() => {
+    const service = new AdoService();
+    service.getWorkItems().then(setItems);
+  }, []);
+
+  return (
+    <div className="mb-4">
+      <h2 className="font-semibold">Work Items</h2>
+      <ul className="list-disc ml-4">
+        {items.map(item => (
+          <li key={item.id}>{item.id}: {item.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/hooks/useWorkBlocks.js
+++ b/src/hooks/useWorkBlocks.js
@@ -1,7 +1,19 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import StorageService from '../services/storageService';
 
 export default function useWorkBlocks() {
   const [blocks, setBlocks] = useState([]);
+
+  useEffect(() => {
+    const storage = new StorageService();
+    const data = storage.read();
+    setBlocks(data.workBlocks || []);
+  }, []);
+
+  useEffect(() => {
+    const storage = new StorageService();
+    storage.write({ workBlocks: blocks });
+  }, [blocks]);
 
   return {
     blocks,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,3 +5,4 @@ import './index.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App />);
+

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -6,6 +6,8 @@ function createWindow() {
     width: 800,
     height: 600,
     webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
       preload: path.join(__dirname, 'preload.js'),
     },
   });

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -6,6 +6,9 @@ export default class AdoService {
 
   async getWorkItems() {
     // TODO: implement fetch from Azure DevOps
-    return [];
+    return [
+      { id: '1001', title: 'Sample Task 1' },
+      { id: '1002', title: 'Sample Task 2' },
+    ];
   }
 }


### PR DESCRIPTION
## Summary
- create Calendar and TaskList components
- persist work blocks locally via new storage hooks
- add stub work items
- update electron main to allow node integration
- document start instructions

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684469bcefc083239f8619df0e81e946