### PR TITLE
Fix storage service for webpack 5

### DIFF
--- a/src/services/storageService.js
+++ b/src/services/storageService.js
@@ -1,20 +1,48 @@
 // Placeholder for local storage interactions
-import fs from 'fs';
-import path from 'path';
+// Dynamically require Node modules when running in Electron
+let fs = null;
+let path = null;
+try {
+  if (typeof window !== 'undefined' && window.require) {
+    fs = window.require('fs');
+    path = window.require('path');
+  }
+} catch (e) {
+  fs = null;
+  path = null;
+}
 
 export default class StorageService {
   constructor() {
-    this.dataPath = path.join(process.cwd(), 'data.json');
+    this.storageKey = 'workBlocks';
+    if (fs && path) {
+      this.dataPath = path.join(process.cwd(), 'data.json');
+    }
   }
 
   read() {
-    if (fs.existsSync(this.dataPath)) {
-      return JSON.parse(fs.readFileSync(this.dataPath));
+    // Prefer filesystem when available (Electron)
+    if (fs && path) {
+      if (fs.existsSync(this.dataPath)) {
+        return JSON.parse(fs.readFileSync(this.dataPath));
+      }
+      return { workBlocks: [] };
+    }
+    // Fallback to browser localStorage
+    if (typeof localStorage !== 'undefined') {
+      const raw = localStorage.getItem(this.storageKey);
+      return raw ? JSON.parse(raw) : { workBlocks: [] };
     }
     return { workBlocks: [] };
   }
 
   write(data) {
-    fs.writeFileSync(this.dataPath, JSON.stringify(data, null, 2));
+    if (fs && path) {
+      fs.writeFileSync(this.dataPath, JSON.stringify(data, null, 2));
+      return;
+    }
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(this.storageKey, JSON.stringify(data));
+    }
   }
 }


### PR DESCRIPTION
## Summary
- prevent webpack errors for Node core modules by using dynamic requires
- use browser localStorage when Node APIs aren't available

## Testing
- `npm run build` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68446b3312a083238794d6b8f03b6626