### PR TITLE
Implement inline calendar entry form

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -2,13 +2,15 @@ import React, { useState } from 'react';
 
 export default function Calendar({ blocks, onAdd }) {
   const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-  const [form, setForm] = useState({ day: 0, start: '09:00', end: '10:00', note: '', workItem: '' });
+  const [activeDay, setActiveDay] = useState(null);
+  const [form, setForm] = useState({ start: '09:00', end: '10:00', note: '', workItem: '' });
 
   const addBlock = (e) => {
     e.preventDefault();
+    if (activeDay === null) return;
     const startDate = new Date();
     const endDate = new Date();
-    startDate.setDate(startDate.getDate() - startDate.getDay() + 1 + parseInt(form.day));
+    startDate.setDate(startDate.getDate() - startDate.getDay() + 1 + parseInt(activeDay));
     endDate.setDate(startDate.getDate());
     startDate.setHours(parseInt(form.start.split(':')[0]), parseInt(form.start.split(':')[1]));
     endDate.setHours(parseInt(form.end.split(':')[0]), parseInt(form.end.split(':')[1]));
@@ -19,34 +21,93 @@ export default function Calendar({ blocks, onAdd }) {
       note: form.note,
       workItem: form.workItem,
     });
-    setForm({ ...form, note: '', workItem: '' });
+    setForm({ start: '09:00', end: '10:00', note: '', workItem: '' });
+    setActiveDay(null);
   };
 
   return (
     <div>
-      <form className="space-x-2 mb-4" onSubmit={addBlock}>
-        <select value={form.day} onChange={(e) => setForm({ ...form, day: e.target.value })}>
-          {days.map((d, idx) => <option key={idx} value={idx}>{d}</option>)}
-        </select>
-        <input type="time" value={form.start} onChange={(e) => setForm({ ...form, start: e.target.value })}/>
-        <input type="time" value={form.end} onChange={(e) => setForm({ ...form, end: e.target.value })}/>
-        <input type="text" placeholder="Work item" value={form.workItem} onChange={(e) => setForm({ ...form, workItem: e.target.value })}/>
-        <input type="text" placeholder="Note" value={form.note} onChange={(e) => setForm({ ...form, note: e.target.value })}/>
-        <button type="submit" className="px-2 py-1 bg-blue-500 text-white">Add</button>
-      </form>
       <div className="grid grid-cols-7 gap-2">
         {days.map((day, idx) => (
-          <div key={idx} className="border p-2">
+          <div
+            key={idx}
+            className="border p-2 relative"
+            onDoubleClick={() => setActiveDay(idx)}
+          >
             <h2 className="font-semibold mb-2">{day}</h2>
-            {blocks.filter(b => {
-              const date = new Date(b.start);
-              return date.getDay() === (idx + 1) % 7;
-            }).map(b => (
-              <div key={b.id} className="mb-2 p-1 bg-gray-200">
-                <div className="text-sm">{new Date(b.start).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})} - {new Date(b.end).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})}</div>
-                <div className="text-xs">{b.workItem} {b.note}</div>
-              </div>
-            ))}
+            {blocks
+              .filter((b) => {
+                const date = new Date(b.start);
+                return date.getDay() === ((idx + 1) % 7);
+              })
+              .map((b) => (
+                <div key={b.id} className="mb-2 p-1 bg-gray-200">
+                  <div className="text-sm">
+                    {new Date(b.start).toLocaleTimeString([], {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}{' '}
+                    -{' '}
+                    {new Date(b.end).toLocaleTimeString([], {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </div>
+                  <div className="text-xs">
+                    {b.workItem} {b.note}
+                  </div>
+                </div>
+              ))}
+            {activeDay === idx && (
+              <form
+                onSubmit={addBlock}
+                className="absolute top-0 left-0 bg-white border p-2 space-y-1 z-10"
+              >
+                <input
+                  type="time"
+                  value={form.start}
+                  onChange={(e) => setForm({ ...form, start: e.target.value })}
+                  className="border"
+                />
+                <input
+                  type="time"
+                  value={form.end}
+                  onChange={(e) => setForm({ ...form, end: e.target.value })}
+                  className="border"
+                />
+                <input
+                  type="text"
+                  placeholder="Work item"
+                  value={form.workItem}
+                  onChange={(e) =>
+                    setForm({ ...form, workItem: e.target.value })
+                  }
+                  className="border"
+                />
+                <input
+                  type="text"
+                  placeholder="Note"
+                  value={form.note}
+                  onChange={(e) => setForm({ ...form, note: e.target.value })}
+                  className="border"
+                />
+                <div className="flex space-x-1">
+                  <button
+                    type="submit"
+                    className="px-2 py-1 bg-blue-500 text-white text-xs"
+                  >
+                    Add
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setActiveDay(null)}
+                    className="px-2 py-1 bg-gray-300 text-xs"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            )}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- enable adding blocks directly on the calendar
- remove the old external form

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446cb01aac832382f9de5f778fa1f1