### PR TITLE
Add colored work item list with hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 
 * Calendar UI (drag to create blocks)
 * Work item panel with filters
+* Color-coded work items by type (tasks yellow, user stories blue, bugs red, features purple)
 * Local draft store (JSON file or SQLite)
 * Manual ADO linking + batch submit
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Calendar from './components/Calendar';
-import TaskList from './components/TaskList';
+import WorkItems from './components/WorkItems';
 import useWorkBlocks from './hooks/useWorkBlocks';
 
 function App() {
@@ -13,7 +13,7 @@ function App() {
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Calendar-Ado MVP</h1>
-      <TaskList />
+      <WorkItems />
       <Calendar blocks={blocks} onAdd={addBlock} />
     </div>
   );

--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function WorkItem({ item, level = 0 }) {
+  const colors = {
+    task: 'bg-yellow-100',
+    'user story': 'bg-blue-100',
+    bug: 'bg-red-100',
+    feature: 'bg-purple-100',
+  };
+
+  const colorClass = colors[item.type?.toLowerCase()] || 'bg-gray-100';
+
+  return (
+    <div
+      className={`p-1 mb-1 border ${colorClass}`}
+      style={{ marginLeft: `${level * 1}rem` }}
+    >
+      <span className="font-mono text-xs mr-1">{item.id}</span>
+      {item.title}
+    </div>
+  );
+}

--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react';
+import useAdoItems from '../hooks/useAdoItems';
+import AdoService from '../services/adoService';
+import WorkItem from './WorkItem';
+
+function buildTree(items) {
+  const map = new Map();
+  items.forEach((item) => {
+    map.set(item.id, { ...item, children: [] });
+  });
+  const roots = [];
+  map.forEach((item) => {
+    if (item.parentId && map.has(item.parentId)) {
+      map.get(item.parentId).children.push(item);
+    } else {
+      roots.push(item);
+    }
+  });
+  return roots;
+}
+
+function renderTree(nodes, level = 0) {
+  return nodes.map((node) => (
+    <div key={node.id}>
+      <WorkItem item={node} level={level} />
+      {node.children.length > 0 && renderTree(node.children, level + 1)}
+    </div>
+  ));
+}
+
+export default function WorkItems() {
+  const { items, setItems } = useAdoItems();
+
+  useEffect(() => {
+    const service = new AdoService();
+    service.getWorkItems().then(setItems);
+  }, []);
+
+  const tree = buildTree(items);
+
+  return (
+    <div className="mb-4">
+      <h2 className="font-semibold">Work Items</h2>
+      <div>{renderTree(tree)}</div>
+    </div>
+  );
+}

--- a/src/models/workItem.js
+++ b/src/models/workItem.js
@@ -1,6 +1,8 @@
 export default class WorkItem {
-  constructor({ id, title }) {
+  constructor({ id, title, type = 'task', parentId = null }) {
     this.id = id;
     this.title = title;
+    this.type = type;
+    this.parentId = parentId;
   }
 }

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -1,4 +1,6 @@
 // Placeholder for Azure DevOps API interactions
+import WorkItem from '../models/workItem';
+
 export default class AdoService {
   constructor(token) {
     this.token = token;
@@ -6,9 +8,15 @@ export default class AdoService {
 
   async getWorkItems() {
     // TODO: implement fetch from Azure DevOps
-    return [
-      { id: '1001', title: 'Sample Task 1' },
-      { id: '1002', title: 'Sample Task 2' },
+    const data = [
+      { id: '2001', title: 'Authentication feature', type: 'feature' },
+      { id: '2002', title: 'Login user story', type: 'user story', parentId: '2001' },
+      { id: '2003', title: 'Implement login page', type: 'task', parentId: '2002' },
+      { id: '2004', title: 'Fix login bug', type: 'bug', parentId: '2002' },
+      { id: '2005', title: 'Profile feature', type: 'feature' },
+      { id: '2006', title: 'Update avatar story', type: 'user story', parentId: '2005' },
+      { id: '2007', title: 'Add file uploader', type: 'task', parentId: '2006' },
     ];
+    return data.map((d) => new WorkItem(d));
   }
 }


### PR DESCRIPTION
## Summary
- implement new `WorkItem` component with color styling
- implement `WorkItems` container to render hierarchy
- extend `AdoService` mock data with types and parent relationships
- add `type` and `parentId` fields to `WorkItem` model
- swap old `TaskList` usage for `WorkItems` in app
- document color coding in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446eb28ee0832389fc9d11633f12b9