### PR TITLE
Reduce work item display size

### DIFF
--- a/src/components/TaskList.jsx
+++ b/src/components/TaskList.jsx
@@ -13,9 +13,11 @@ export default function TaskList() {
   return (
     <div className="mb-4">
       <h2 className="font-semibold">Work Items</h2>
-      <ul className="list-disc ml-4">
-        {items.map(item => (
-          <li key={item.id}>{item.id}: {item.title}</li>
+      <ul className="list-disc ml-4 text-xs space-y-1">
+        {items.map((item) => (
+          <li key={item.id} className="truncate">
+            {item.id}: {item.title}
+          </li>
         ))}
       </ul>
     </div>

--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -12,10 +12,10 @@ export default function WorkItem({ item, level = 0 }) {
 
   return (
     <div
-      className={`p-1 mb-1 border ${colorClass}`}
+      className={`p-1 mb-1 border ${colorClass} text-xs truncate`}
       style={{ marginLeft: `${level * 1}rem` }}
     >
-      <span className="font-mono text-xs mr-1">{item.id}</span>
+      <span className="font-mono mr-1">{item.id}</span>
       {item.title}
     </div>
   );


### PR DESCRIPTION
## Summary
- make WorkItem text tiny with ellipsis
- make TaskList items tiny with ellipsis

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68447099c4cc8323a12dcf67957d285b