### PR TITLE
Add block deletion with confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 * Reuse previous week's structure for recurring patterns
 * Hover tooltip for blocks showing title, linked task, time spent, and sync status
 * Editable area path/job order hints for numeric values (e.g., "1234 → Billing team Q2")
+* Hover highlight with delete icon to remove a block after confirmation
 
 ---
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,12 +11,16 @@ function App() {
     setBlocks([...blocks, block]);
   };
 
+  const deleteBlock = (id) => {
+    setBlocks(blocks.filter((b) => b.id !== id));
+  };
+
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Calendar-Ado MVP</h1>
       <HoursSummary blocks={blocks} />
       <WorkItems />
-      <Calendar blocks={blocks} onAdd={addBlock} />
+      <Calendar blocks={blocks} onAdd={addBlock} onDelete={deleteBlock} />
     </div>
   );
 }

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
 
-export default function Calendar({ blocks, onAdd }) {
+export default function Calendar({ blocks, onAdd, onDelete }) {
   const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
   const hours = Array.from({ length: 24 }, (_, i) => i.toString().padStart(2, '0'));
   const hourHeight = 40; // px height for each hour block
   const [activeDay, setActiveDay] = useState(null);
   const [form, setForm] = useState({ start: '09:00', end: '10:00', note: '', workItem: '' });
   const [drag, setDrag] = useState(null); // { day, start, end }
+  const [hoveredId, setHoveredId] = useState(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState(null);
 
   const addBlock = (e) => {
     e.preventDefault();
@@ -99,10 +101,16 @@ export default function Calendar({ blocks, onAdd }) {
                     const endMinutes = end.getHours() * 60 + end.getMinutes();
                     const top = startMinutes * (hourHeight / 60);
                     const height = (endMinutes - startMinutes) * (hourHeight / 60);
+                    const highlight = hoveredId === b.id;
                     return (
                       <div
                         key={b.id}
-                        className="absolute left-0 right-0 p-1 bg-gray-200 overflow-hidden"
+                        onMouseEnter={() => setHoveredId(b.id)}
+                        onMouseLeave={() => {
+                          setHoveredId(null);
+                          if (confirmDeleteId !== b.id) setConfirmDeleteId(null);
+                        }}
+                        className={`absolute left-0 right-0 p-1 bg-gray-200 overflow-hidden ${highlight ? 'ring-2 ring-blue-400' : ''}`}
                         style={{ top: `${top}px`, height: `${height}px` }}
                       >
                         <div className="text-sm">
@@ -119,6 +127,34 @@ export default function Calendar({ blocks, onAdd }) {
                         <div className="text-xs">
                           {b.workItem} {b.note}
                         </div>
+                        {highlight && confirmDeleteId !== b.id && (
+                          <button
+                            className="absolute bottom-0 right-0 p-1 text-red-600 text-xs bg-white"
+                            onClick={() => setConfirmDeleteId(b.id)}
+                          >
+                            🗑
+                          </button>
+                        )}
+                        {confirmDeleteId === b.id && (
+                          <div className="absolute bottom-0 right-0 flex space-x-1 text-xs">
+                            <button
+                              className="px-1 bg-red-500 text-white"
+                              onClick={() => {
+                                if (onDelete) onDelete(b.id);
+                                setConfirmDeleteId(null);
+                                setHoveredId(null);
+                              }}
+                            >
+                              Confirm?
+                            </button>
+                            <button
+                              className="px-1 bg-gray-300"
+                              onClick={() => setConfirmDeleteId(null)}
+                            >
+                              x
+                            </button>
+                          </div>
+                        )}
                       </div>
                     );
                   })}


### PR DESCRIPTION
## Summary
- enable deleting blocks from Calendar
- highlight block on hover with delete basket
- confirm before removing a block
- document the new feature

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68447374456483239e2dd548d90ab5f4