### PR TITLE
Fix drag creation on block delete

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -31,6 +31,10 @@ export default function Calendar({ blocks, onAdd, onDelete }) {
   };
 
   const startDrag = (e, dayIdx) => {
+    // ignore drags that originate from interactive elements like buttons or the form
+    if (e.target.closest('button') || e.target.closest('input') || e.target.closest('form')) {
+      return;
+    }
     const rect = e.currentTarget.getBoundingClientRect();
     const hourHeight = rect.height / hours.length;
     const start = Math.floor((e.clientY - rect.top) / hourHeight);
@@ -68,7 +72,16 @@ export default function Calendar({ blocks, onAdd, onDelete }) {
           <div
             key={idx}
             className="border p-2 relative"
-            onDoubleClick={() => setActiveDay(idx)}
+            onDoubleClick={(e) => {
+              if (
+                e.target.closest('button') ||
+                e.target.closest('input') ||
+                e.target.closest('form')
+              ) {
+                return;
+              }
+              setActiveDay(idx);
+            }}
           >
             <h2 className="font-semibold mb-2">{day}</h2>
             <div


### PR DESCRIPTION
## Summary
- stop starting drag when clicking on buttons or form elements
- avoid opening add-block form when double-clicking interactive elements

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447484ddcc8323aec96e52f4e73619