### PR TITLE
Prevent overlapping work blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 * Entry status: draft, linked, submitted
 * Drag on calendar to create "shell" work blocks
 * Suggested work item overlay when a block is created
+* Prevent overlapping blocks to discourage multitasking
 
 ### 3.2 ADO Work Item Panel
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,8 +7,22 @@ import useWorkBlocks from './hooks/useWorkBlocks';
 function App() {
   const { blocks, setBlocks } = useWorkBlocks();
 
+  const hasOverlap = (newBlock) => {
+    const newStart = new Date(newBlock.start);
+    const newEnd = new Date(newBlock.end);
+    return blocks.some((b) => {
+      const start = new Date(b.start);
+      const end = new Date(b.end);
+      return newStart < end && newEnd > start;
+    });
+  };
+
   const addBlock = (block) => {
-    setBlocks([...blocks, block]);
+    if (hasOverlap(block)) {
+      alert('Cannot create overlapping work blocks.');
+      return;
+    }
+    setBlocks((prev) => [...prev, block]);
   };
 
   const deleteBlock = (id) => {


### PR DESCRIPTION
## Summary
- disallow adding calendar entries that collide with existing ones
- document that overlapping blocks are not allowed

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6844757fcd6c8323ad736cc3e7d43937