### PR TITLE
Add lunch break settings

### DIFF
--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -57,6 +57,32 @@ export default function Settings({ settings, setSettings }) {
             />
           </div>
           <div>
+            <label className="mr-1">Lunch start:</label>
+            <input
+              type="number"
+              min="0"
+              max="23"
+              value={temp.lunchStart}
+              onChange={(e) =>
+                setTemp({ ...temp, lunchStart: parseInt(e.target.value) })
+              }
+              className="border w-16"
+            />
+          </div>
+          <div>
+            <label className="mr-1">Lunch end:</label>
+            <input
+              type="number"
+              min="1"
+              max="24"
+              value={temp.lunchEnd}
+              onChange={(e) =>
+                setTemp({ ...temp, lunchEnd: parseInt(e.target.value) })
+              }
+              className="border w-16"
+            />
+          </div>
+          <div>
             <div className="mb-1">Work days:</div>
             <div className="flex space-x-2 flex-wrap">
               {dayNames.map((d, idx) => (

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -4,6 +4,8 @@ import StorageService from '../services/storageService';
 const defaultSettings = {
   startHour: 9,
   endHour: 17,
+  lunchStart: 12,
+  lunchEnd: 13,
   workDays: [0, 1, 2, 3, 4],
 };
 


### PR DESCRIPTION
## Summary
- allow configuring lunch break start and end times
- persist lunch break values in settings

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447676f9f48323b766da0f52643d76