### PR TITLE
Add week navigation with real calendar dates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Calendar from './components/Calendar';
 import HoursSummary from './components/HoursSummary';
 import WorkItems from './components/WorkItems';
@@ -9,6 +9,31 @@ import useSettings from './hooks/useSettings';
 function App() {
   const { blocks, setBlocks } = useWorkBlocks();
   const { settings, setSettings } = useSettings();
+
+  const getWeekStart = (date) => {
+    const d = new Date(date);
+    const day = d.getDay();
+    const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+    d.setDate(diff);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  };
+
+  const [weekStart, setWeekStart] = useState(getWeekStart(new Date()));
+
+  const prevWeek = () =>
+    setWeekStart((w) => new Date(w.getTime() - 7 * 24 * 60 * 60 * 1000));
+  const nextWeek = () =>
+    setWeekStart((w) => new Date(w.getTime() + 7 * 24 * 60 * 60 * 1000));
+  const currentWeek = () => setWeekStart(getWeekStart(new Date()));
+
+  const formatRange = () => {
+    const end = new Date(weekStart);
+    end.setDate(weekStart.getDate() + 6);
+    return `${weekStart.getMonth() + 1}/${weekStart.getDate()} - ${
+      end.getMonth() + 1
+    }/${end.getDate()}`;
+  };
 
   const isOverlappingLunch = (block) => {
     const start = new Date(block.start);
@@ -119,11 +144,24 @@ function App() {
     <div className="p-4 flex">
       <div className="flex-grow">
         <h1 className="text-2xl font-bold mb-4">Calendar-Ado MVP</h1>
+        <div className="mb-2 space-x-2">
+          <button className="px-2 py-1 bg-gray-200" onClick={prevWeek}>
+            Prev Week
+          </button>
+          <button className="px-2 py-1 bg-gray-200" onClick={currentWeek}>
+            This Week
+          </button>
+          <button className="px-2 py-1 bg-gray-200" onClick={nextWeek}>
+            Next Week
+          </button>
+          <span className="ml-2 font-semibold">{formatRange()}</span>
+        </div>
         <Calendar
           blocks={blocks}
           onAdd={addBlock}
           settings={settings}
           onDelete={deleteBlock}
+          weekStart={weekStart}
         />
       </div>
       <div className="w-64 pl-4 space-y-4">

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,8 +1,19 @@
 import React, { useState } from 'react';
 
-export default function Calendar({ blocks, onAdd, settings, onDelete }) {
+export default function Calendar({
+  blocks,
+  onAdd,
+  settings,
+  onDelete,
+  weekStart,
+}) {
   const weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
   const days = settings.workDays;
+  const weekDates = days.map((d) => {
+    const date = new Date(weekStart);
+    date.setDate(weekStart.getDate() + d);
+    return date;
+  });
   const hours = Array.from(
     { length: settings.endHour - settings.startHour },
     (_, i) => (i + settings.startHour).toString().padStart(2, '0')
@@ -23,10 +34,9 @@ export default function Calendar({ blocks, onAdd, settings, onDelete }) {
   const addBlock = (e) => {
     e.preventDefault();
     if (activeDay === null) return;
-    const startDate = new Date();
-    const endDate = new Date();
-    startDate.setDate(startDate.getDate() - startDate.getDay() + 1 + parseInt(activeDay));
-    endDate.setDate(startDate.getDate());
+    const startDate = new Date(weekStart);
+    startDate.setDate(weekStart.getDate() + parseInt(activeDay));
+    const endDate = new Date(startDate);
     startDate.setHours(parseInt(form.start.split(':')[0]), parseInt(form.start.split(':')[1]));
     endDate.setHours(parseInt(form.end.split(':')[0]), parseInt(form.end.split(':')[1]));
     onAdd({
@@ -77,10 +87,9 @@ export default function Calendar({ blocks, onAdd, settings, onDelete }) {
       setDrag(null);
       return;
     }
-    const startDate = new Date();
-    const endDate = new Date();
-    startDate.setDate(startDate.getDate() - startDate.getDay() + 1 + dayIdx);
-    endDate.setDate(startDate.getDate());
+    const startDate = new Date(weekStart);
+    startDate.setDate(weekStart.getDate() + dayIdx);
+    const endDate = new Date(startDate);
     startDate.setHours(
       settings.startHour + Math.floor(drag.start / 60),
       drag.start % 60,
@@ -112,10 +121,12 @@ export default function Calendar({ blocks, onAdd, settings, onDelete }) {
               ) {
                 return;
               }
-              setActiveDay(idx);
+              setActiveDay(dayIdx);
             }}
           >
-            <h2 className="font-semibold mb-2">{weekDays[dayIdx]}</h2>
+            <h2 className="font-semibold mb-2">
+              {weekDays[dayIdx]} {weekDates[idx].getMonth() + 1}/{weekDates[idx].getDate()}
+            </h2>
             <div
               className="relative select-none"
               style={{ height: `${hours.length * hourHeight}px` }}
@@ -147,7 +158,9 @@ export default function Calendar({ blocks, onAdd, settings, onDelete }) {
                 {blocks
                   .filter((b) => {
                     const date = new Date(b.start);
-                    return date.getDay() === ((dayIdx + 1) % 7);
+                    const dayDate = new Date(weekStart);
+                    dayDate.setDate(weekStart.getDate() + dayIdx);
+                    return date.toDateString() === dayDate.toDateString();
                   })
                   .map((b) => {
                     const start = new Date(b.start);


### PR DESCRIPTION
## Summary
- allow navigation between weeks and show current week range
- display each calendar day with its actual date
- store week start so blocks are added to the selected week

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68447fc045d88323969430e10c67f9bf