### PR TITLE
Filter HoursSummary by current week

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -166,7 +166,7 @@ function App() {
       </div>
       <div className="w-64 pl-4 space-y-4">
         <Settings settings={settings} setSettings={setSettings} />
-        <HoursSummary blocks={blocks} />
+        <HoursSummary blocks={blocks} weekStart={weekStart} />
         <WorkItems />
       </div>
     </div>

--- a/src/components/HoursSummary.jsx
+++ b/src/components/HoursSummary.jsx
@@ -1,12 +1,20 @@
 import React from 'react';
 
-export default function HoursSummary({ blocks }) {
-  const totalHours = blocks.reduce((sum, b) => {
-    const start = new Date(b.start);
-    const end = new Date(b.end);
-    const diff = (end - start) / (1000 * 60 * 60);
-    return sum + diff;
-  }, 0);
+export default function HoursSummary({ blocks, weekStart }) {
+  const weekEnd = new Date(weekStart);
+  weekEnd.setDate(weekStart.getDate() + 7);
+
+  const totalHours = blocks
+    .filter((b) => {
+      const start = new Date(b.start);
+      return start >= weekStart && start < weekEnd;
+    })
+    .reduce((sum, b) => {
+      const start = new Date(b.start);
+      const end = new Date(b.end);
+      const diff = (end - start) / (1000 * 60 * 60);
+      return sum + diff;
+    }, 0);
   const overLimit = totalHours > 40;
   const textColor = overLimit ? 'text-red-600' : 'text-gray-800';
 


### PR DESCRIPTION
## Summary
- update HoursSummary to take `weekStart` and sum only visible week
- pass `weekStart` from App when rendering HoursSummary

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684480f0745883238039a97c013515ad