### PR TITLE
Add dark mode setting

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,14 @@ function App() {
   const { items, setItems } = useAdoItems();
 
   useEffect(() => {
+    if (settings.darkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [settings.darkMode]);
+
+  useEffect(() => {
     const service = new AdoService();
     service.getWorkItems().then(setItems);
   }, [setItems]);
@@ -217,17 +225,17 @@ function App() {
   };
 
   return (
-    <div className="p-4 flex">
+    <div className="p-4 flex min-h-screen bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100">
       <div className="flex-grow">
         <h1 className="text-2xl font-bold mb-4">Calendar-Ado MVP</h1>
         <div className="mb-2 space-x-2">
-          <button className="px-2 py-1 bg-gray-200" onClick={prevWeek}>
+          <button className="px-2 py-1 bg-gray-200 dark:bg-gray-700" onClick={prevWeek}>
             Prev Week
           </button>
-          <button className="px-2 py-1 bg-gray-200" onClick={currentWeek}>
+          <button className="px-2 py-1 bg-gray-200 dark:bg-gray-700" onClick={currentWeek}>
             This Week
           </button>
-          <button className="px-2 py-1 bg-gray-200" onClick={nextWeek}>
+          <button className="px-2 py-1 bg-gray-200 dark:bg-gray-700" onClick={nextWeek}>
             Next Week
           </button>
           <span className="ml-2 font-semibold">{formatRange()}</span>

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -344,7 +344,7 @@ export default function Calendar({
                             e.currentTarget.style.cursor = 'move';
                           }
                         }}
-                        className={`work-block absolute left-0 right-0 p-1 border rounded-md overflow-hidden select-none text-[10px] leading-tight ${b.taskId ? 'bg-blue-200 border-blue-300' : 'bg-gray-100 border-gray-300'} ${b.taskId && b.workItem ? 'border-yellow-400' : ''} ${highlight ? 'ring-2 ring-blue-400' : ''}`}
+                        className={`work-block absolute left-0 right-0 p-1 border rounded-md overflow-hidden select-none text-[10px] leading-tight ${b.taskId ? 'bg-blue-200 border-blue-300' : 'bg-gray-100 dark:bg-gray-700 border-gray-300 dark:border-gray-600'} ${b.taskId && b.workItem ? 'border-yellow-400' : ''} ${highlight ? 'ring-2 ring-blue-400' : ''}`}
                         style={{ top: `${top}px`, height: `${height}px` }}
                       >
                         <div className="text-[10px]">
@@ -379,7 +379,7 @@ export default function Calendar({
                         </div>
                         {highlight && confirmDeleteId !== b.id && (
                           <button
-                            className="absolute bottom-0 right-0 p-1 text-red-600 text-xs bg-white"
+                          className="absolute bottom-0 right-0 p-1 text-red-600 text-xs bg-white dark:bg-gray-800"
                             onClick={() => setConfirmDeleteId(b.id)}
                           >
                             🗑
@@ -398,7 +398,7 @@ export default function Calendar({
                               Confirm?
                             </button>
                             <button
-                              className="px-1 bg-gray-300"
+                              className="px-1 bg-gray-300 dark:bg-gray-600"
                               onClick={() => setConfirmDeleteId(null)}
                             >
                               x
@@ -411,7 +411,7 @@ export default function Calendar({
                 {activeDay === dayIdx && (
                   <form
                     onSubmit={addBlock}
-                    className="absolute top-0 left-0 bg-white border p-2 space-y-1 z-20"
+                    className="absolute top-0 left-0 bg-white dark:bg-gray-800 border p-2 space-y-1 z-20"
                   >
                     <input
                       type="time"
@@ -453,7 +453,7 @@ export default function Calendar({
                       <button
                         type="button"
                         onClick={() => setActiveDay(null)}
-                        className="px-2 py-1 bg-gray-300 text-xs"
+                        className="px-2 py-1 bg-gray-300 dark:bg-gray-600 text-xs"
                       >
                         Cancel
                       </button>
@@ -476,13 +476,13 @@ export default function Calendar({
       </div>
       {taskSelect && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white p-4 max-h-64 overflow-y-auto">
+          <div className="bg-white dark:bg-gray-800 dark:text-white p-4 max-h-64 overflow-y-auto">
             <h3 className="font-semibold mb-2">Select Task for {taskSelect.parent.title}</h3>
             <ul>
               {taskSelect.tasks.map((t) => (
                 <li
                   key={t.id}
-                  className="p-1 cursor-pointer hover:bg-gray-100 text-sm"
+                  className="p-1 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 text-sm"
                   onClick={() => {
                     if (onUpdate)
                       onUpdate(taskSelect.blockId, { workItem: taskSelect.parent.title, taskId: t.id });
@@ -493,7 +493,7 @@ export default function Calendar({
                 </li>
               ))}
             </ul>
-            <button className="mt-2 px-2 py-1 bg-gray-300" onClick={() => setTaskSelect(null)}>
+            <button className="mt-2 px-2 py-1 bg-gray-300 dark:bg-gray-600" onClick={() => setTaskSelect(null)}>
               Cancel
             </button>
           </div>

--- a/src/components/HoursSummary.jsx
+++ b/src/components/HoursSummary.jsx
@@ -28,7 +28,7 @@ export default function HoursSummary({ blocks, weekStart }) {
       return sum + diff;
     }, 0);
   const overLimit = totalHours > 40;
-  const textColor = overLimit ? 'text-red-600' : 'text-gray-800';
+  const textColor = overLimit ? 'text-red-600' : 'text-gray-800 dark:text-gray-200';
 
   return (
     <div className="mb-4">

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -23,114 +23,128 @@ export default function Settings({ settings, setSettings }) {
     setOpen(false);
   };
 
-    return (
-      <div className="mb-2">
-        <button className="px-2 py-1 bg-gray-200" onClick={() => setOpen(true)}>
-          Settings
-        </button>
-        {open && (
-          <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
-            <div className="border p-4 bg-white space-y-2 shadow-lg">
-              <div>
-            <label className="mr-1">Start hour:</label>
-            <input
-              type="number"
-              min="0"
-              max="23"
-              value={temp.startHour}
-              onChange={(e) =>
-                setTemp({ ...temp, startHour: parseInt(e.target.value) })
-              }
-              className="border w-16"
-            />
-          </div>
-          <div>
-            <label className="mr-1">End hour:</label>
-            <input
-              type="number"
-              min="1"
-              max="24"
-              value={temp.endHour}
-              onChange={(e) =>
-                setTemp({ ...temp, endHour: parseInt(e.target.value) })
-              }
-              className="border w-16"
-            />
-          </div>
-          <div>
-            <label className="mr-1">Lunch start:</label>
-            <input
-              type="number"
-              min="0"
-              max="23"
-              value={temp.lunchStart}
-              onChange={(e) =>
-                setTemp({ ...temp, lunchStart: parseInt(e.target.value) })
-              }
-              className="border w-16"
-            />
-          </div>
-          <div>
-            <label className="mr-1">Lunch end:</label>
-            <input
-              type="number"
-              min="1"
-              max="24"
-              value={temp.lunchEnd}
-              onChange={(e) =>
-                setTemp({ ...temp, lunchEnd: parseInt(e.target.value) })
-              }
-              className="border w-16"
-            />
-          </div>
-          <div>
-            <label className="mr-1">Block size:</label>
-            <select
-              value={temp.blockMinutes}
-              onChange={(e) =>
-                setTemp({ ...temp, blockMinutes: parseInt(e.target.value) })
-              }
-              className="border"
-            >
-              {[10, 15, 30, 60].map((m) => (
-                <option key={m} value={m}>
-                  {m === 60 ? '1 h' : `${m} min`}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <div className="mb-1">Work days:</div>
-            <div className="flex space-x-2 flex-wrap">
-              {dayNames.map((d, idx) => (
-                <label key={idx} className="flex items-center space-x-1">
-                  <input
-                    type="checkbox"
-                    checked={temp.workDays.includes(idx)}
-                    onChange={() => toggleDay(idx)}
-                  />
-                  <span>{d}</span>
-                </label>
-              ))}
+  return (
+    <div className="mb-2">
+      <button
+        className="px-2 py-1 bg-gray-200 dark:bg-gray-700"
+        onClick={() => setOpen(true)}
+      >
+        Settings
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
+          <div className="border p-4 bg-white dark:bg-gray-800 dark:text-white space-y-2 shadow-lg">
+            <div>
+              <label className="mr-1">Start hour:</label>
+              <input
+                type="number"
+                min="0"
+                max="23"
+                value={temp.startHour}
+                onChange={(e) =>
+                  setTemp({ ...temp, startHour: parseInt(e.target.value) })
+                }
+                className="border w-16"
+              />
+            </div>
+            <div>
+              <label className="mr-1">End hour:</label>
+              <input
+                type="number"
+                min="1"
+                max="24"
+                value={temp.endHour}
+                onChange={(e) =>
+                  setTemp({ ...temp, endHour: parseInt(e.target.value) })
+                }
+                className="border w-16"
+              />
+            </div>
+            <div>
+              <label className="mr-1">Lunch start:</label>
+              <input
+                type="number"
+                min="0"
+                max="23"
+                value={temp.lunchStart}
+                onChange={(e) =>
+                  setTemp({ ...temp, lunchStart: parseInt(e.target.value) })
+                }
+                className="border w-16"
+              />
+            </div>
+            <div>
+              <label className="mr-1">Lunch end:</label>
+              <input
+                type="number"
+                min="1"
+                max="24"
+                value={temp.lunchEnd}
+                onChange={(e) =>
+                  setTemp({ ...temp, lunchEnd: parseInt(e.target.value) })
+                }
+                className="border w-16"
+              />
+            </div>
+            <div>
+              <label className="mr-1">Block size:</label>
+              <select
+                value={temp.blockMinutes}
+                onChange={(e) =>
+                  setTemp({ ...temp, blockMinutes: parseInt(e.target.value) })
+                }
+                className="border"
+              >
+                {[10, 15, 30, 60].map((m) => (
+                  <option key={m} value={m}>
+                    {m === 60 ? '1 h' : `${m} min`}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <div className="mb-1">Work days:</div>
+              <div className="flex space-x-2 flex-wrap">
+                {dayNames.map((d, idx) => (
+                  <label key={idx} className="flex items-center space-x-1">
+                    <input
+                      type="checkbox"
+                      checked={temp.workDays.includes(idx)}
+                      onChange={() => toggleDay(idx)}
+                    />
+                    <span>{d}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div className="flex items-center space-x-2">
+              <label className="flex items-center space-x-1">
+                <input
+                  type="checkbox"
+                  checked={temp.darkMode}
+                  onChange={() => setTemp({ ...temp, darkMode: !temp.darkMode })}
+                />
+                <span>Dark mode</span>
+              </label>
+            </div>
+            <div className="flex space-x-2">
+              <button className="px-2 py-1 bg-blue-500 text-white text-xs" onClick={save}>
+                Save
+              </button>
+              <button
+                className="px-2 py-1 bg-gray-300 dark:bg-gray-600 text-xs"
+                onClick={() => {
+                  setTemp(settings);
+                  setOpen(false);
+                }}
+              >
+                Cancel
+              </button>
             </div>
           </div>
-          <div className="flex space-x-2">
-            <button className="px-2 py-1 bg-blue-500 text-white text-xs" onClick={save}>
-              Save
-            </button>
-            <button
-              className="px-2 py-1 bg-gray-300 text-xs"
-              onClick={() => {
-                setTemp(settings);
-                setOpen(false);
-              }}
-            >
-              Cancel
-            </button>
-          </div>
         </div>
-      </div>
       )}
     </div>
   );
 }
+

--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 export default function WorkItem({ item, level = 0 }) {
   const colors = {
-    task: 'bg-yellow-100',
-    'user story': 'bg-blue-100',
-    bug: 'bg-red-100',
-    feature: 'bg-purple-100',
+    task: 'bg-yellow-100 dark:bg-yellow-700',
+    'user story': 'bg-blue-100 dark:bg-blue-700',
+    bug: 'bg-red-100 dark:bg-red-700',
+    feature: 'bg-purple-100 dark:bg-purple-700',
   };
 
-  const colorClass = colors[item.type?.toLowerCase()] || 'bg-gray-100';
+  const colorClass = colors[item.type?.toLowerCase()] || 'bg-gray-100 dark:bg-gray-700';
   const isFeature = item.type?.toLowerCase() === 'feature';
 
   const dragStart = (e) => {
@@ -20,7 +20,7 @@ export default function WorkItem({ item, level = 0 }) {
 
   return isFeature ? (
     <div
-      className="inline-block rounded-full px-2 py-1 bg-purple-200 text-xs font-semibold mr-2 mb-2"
+      className="inline-block rounded-full px-2 py-1 bg-purple-200 dark:bg-purple-700 text-xs font-semibold mr-2 mb-2"
       draggable
       onDragStart={dragStart}
     >

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -8,6 +8,7 @@ const defaultSettings = {
   lunchEnd: 13,
   workDays: [0, 1, 2, 3, 4],
   blockMinutes: 15,
+  darkMode: false,
 };
 
 export default function useSettings() {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   content: ['./src/**/*.{js,jsx}', './public/index.html'],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- add darkMode setting saved with other preferences
- implement dark mode toggle in Settings modal
- enable Tailwind dark mode via class strategy
- apply dark styles across components

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448e6372088323945a97939c1cfb0b