### PR TITLE
Adjust light mode palette

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Calendar ADO</title>
 </head>
-<body>
+<body class="bg-yellow-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
   <div id="root"></div>
 </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -225,7 +225,7 @@ function App() {
   };
 
   return (
-    <div className="p-4 flex min-h-screen bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100">
+    <div className="p-4 flex min-h-screen bg-yellow-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
       <div className="flex-grow">
         <h1 className="text-2xl font-bold mb-4">Calendar-Ado MVP</h1>
         <div className="mb-2 space-x-2">

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -379,7 +379,7 @@ export default function Calendar({
                         </div>
                         {highlight && confirmDeleteId !== b.id && (
                           <button
-                          className="absolute bottom-0 right-0 p-1 text-red-600 text-xs bg-white dark:bg-gray-800"
+                          className="absolute bottom-0 right-0 p-1 text-red-600 text-xs bg-yellow-50 dark:bg-gray-800"
                             onClick={() => setConfirmDeleteId(b.id)}
                           >
                             🗑
@@ -411,7 +411,7 @@ export default function Calendar({
                 {activeDay === dayIdx && (
                   <form
                     onSubmit={addBlock}
-                    className="absolute top-0 left-0 bg-white dark:bg-gray-800 border p-2 space-y-1 z-20"
+                    className="absolute top-0 left-0 bg-yellow-50 dark:bg-gray-800 border p-2 space-y-1 z-20"
                   >
                     <input
                       type="time"
@@ -476,7 +476,7 @@ export default function Calendar({
       </div>
       {taskSelect && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 dark:text-white p-4 max-h-64 overflow-y-auto">
+          <div className="bg-yellow-50 dark:bg-gray-800 dark:text-white p-4 max-h-64 overflow-y-auto">
             <h3 className="font-semibold mb-2">Select Task for {taskSelect.parent.title}</h3>
             <ul>
               {taskSelect.tasks.map((t) => (

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -33,7 +33,7 @@ export default function Settings({ settings, setSettings }) {
       </button>
       {open && (
         <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
-          <div className="border p-4 bg-white dark:bg-gray-800 dark:text-white space-y-2 shadow-lg">
+          <div className="border p-4 bg-yellow-50 dark:bg-gray-800 dark:text-white space-y-2 shadow-lg">
             <div>
               <label className="mr-1">Start hour:</label>
               <input


### PR DESCRIPTION
## Summary
- use soft yellow background in light mode
- match settings popup and calendar overlays

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844914c1b308323a446c87684875cac