### PR TITLE
Display parent feature prominently

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -384,12 +384,26 @@ export default function Calendar({
                             return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
                           })()}
                         </div>
-                        <div className="text-[10px] flex flex-wrap items-center gap-1">
-                          {b.itemId && <ItemBubble item={findItem(b.itemId)} />}
-                          {b.taskId && (
-                            <ItemBubble item={findItem(b.taskId)} />
-                          )}
-                          {b.workItem && (
+                        <div className="text-[10px] flex flex-col gap-1">
+                          {(() => {
+                            const item = b.itemId ? findItem(b.itemId) : null;
+                            const task = b.taskId ? findItem(b.taskId) : null;
+                            const hasParent = item && task && item.id !== task.id;
+                            if (item) {
+                              return (
+                                <div className="flex flex-col gap-1">
+                                  <ItemBubble item={item} full />
+                                  {hasParent && (
+                                    <div className="pl-2">
+                                      <ItemBubble item={task} />
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            }
+                            return task ? <ItemBubble item={task} /> : null;
+                          })()}
+                          {!b.itemId && b.workItem && (
                             <span className="bg-gray-200 dark:bg-gray-700 rounded px-1">
                               {b.workItem}
                             </span>

--- a/src/components/ItemBubble.jsx
+++ b/src/components/ItemBubble.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function ItemBubble({ item }) {
+export default function ItemBubble({ item, full = false }) {
   if (!item) return null;
   const colors = {
     task: 'bg-yellow-200 dark:bg-yellow-700',
@@ -9,7 +9,12 @@ export default function ItemBubble({ item }) {
     feature: 'bg-purple-200 dark:bg-purple-700',
   };
   const colorClass = colors[item.type?.toLowerCase()] || 'bg-gray-200 dark:bg-gray-700';
+  const displayClass = full ? 'block w-full text-center' : 'inline-block';
   return (
-    <span className={`inline-block rounded-full px-2 py-1 text-xs font-semibold ${colorClass}`}>{item.title}</span>
+    <span
+      className={`${displayClass} rounded-full px-2 py-1 text-xs font-semibold ${colorClass}`}
+    >
+      {item.title}
+    </span>
   );
 }


### PR DESCRIPTION
## Summary
- allow `ItemBubble` to render full-width labels
- show parent item as a full-width bubble on calendar blocks
- nest task bubble within the parent feature when present

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684495e73ef4832398073e11a28a1493