### PR TITLE
Add work item filtering UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 ### 3.2 ADO Work Item Panel
 
 * Scrollable list of work items pinned at top of the app window
+* Search box and type filter to narrow visible items
 * Toggle visibility by clicking on "Features" or filter tags
 * Work items scored and sorted by a blend of:
 
@@ -158,7 +159,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 ### Phase 1 – MVP
 
 * Calendar UI (drag to create blocks)
-* Work item panel with filters
+* Work item panel with search and type filters
 * Color-coded work items by type (tasks yellow, user stories blue, bugs red, features purple)
 * Local draft store (JSON file or SQLite)
 * Manual ADO linking + batch submit

--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import AdoService from '../services/adoService';
 import WorkItem from './WorkItem';
 
@@ -39,11 +39,44 @@ export default function WorkItems({ items, setItems }) {
     }
   }, [items, setItems]);
 
-  const tree = buildTree(items);
+  const [search, setSearch] = useState('');
+  const [typeFilter, setTypeFilter] = useState('all');
+
+  const filtered = items.filter((i) => {
+    const matchesSearch = i.title
+      .toLowerCase()
+      .includes(search.toLowerCase());
+    const matchesType =
+      typeFilter === 'all' ||
+      i.type?.toLowerCase() === typeFilter;
+    return matchesSearch && matchesType;
+  });
+
+  const tree = buildTree(filtered);
 
   return (
     <div className="mb-4">
       <h2 className="font-semibold">Work Items</h2>
+      <div className="flex space-x-2 mb-2">
+        <input
+          type="text"
+          placeholder="Search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="border px-1 text-sm flex-grow"
+        />
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          className="border text-sm"
+        >
+          <option value="all">All</option>
+          <option value="feature">Features</option>
+          <option value="user story">User Stories</option>
+          <option value="bug">Bugs</option>
+          <option value="task">Tasks</option>
+        </select>
+      </div>
       <div>{renderTree(tree)}</div>
     </div>
   );


### PR DESCRIPTION
## Summary
- implement search and type filtering in the work item panel
- document filters in the README

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844992a04a08323b9c8b81bb7b9a069