### PR TITLE
Move react-scripts to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
   },
   "devDependencies": {
     "concurrently": "^8.0.0",
     "electron": "^29.0.0",
     "electron-builder": "^24.0.0",
-    "react-scripts": "5.0.1",
     "tailwindcss": "^3.4.0",
     "postcss": "^8.4.0",
     "autoprefixer": "^10.4.0"


### PR DESCRIPTION
## Summary
- shift `react-scripts` from devDependencies to dependencies

## Testing
- `npm run build` *(fails: react-scripts not installed)*
- `npm install` *(fails due to registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68449bd791908323a0cd1e11e2ff3ff7