### PR TITLE
Improve PAT handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 
 ### 4.3 Sync & Auth
 
-* PAT stored securely using `keytar` in Electron main process
+* PAT stored securely using `keytar` in Electron. In the browser the token is
+  kept in session storage only and never written to disk.
 * ADO sync fetches latest work items nightly or on-demand
 
 ---
@@ -134,7 +135,8 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 
 **Security**:
 
-* PAT stored securely via `keytar`
+* PAT stored securely via `keytar`; falls back to session storage when keytar is
+  unavailable
 * No external cloud storage
 * Local-only execution unless user opts into sync
 
@@ -210,7 +212,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 * Scaffold Electron + React project
 * Set up calendar grid and time block model
 * Connect to ADO API with manual PAT test
-* Implement secure PAT storage with `keytar`
+* Implement secure PAT storage with `keytar` (with session storage fallback)
 * Create local storage service (JSON-based MVP)
 
 ---
@@ -226,9 +228,10 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 
 2. **Authentication Layer**
 
-   * `adoService.js`: handles API calls with PAT
-   * `keytar`: store and retrieve PAT securely
-   * Settings screen to input/test PAT
+  * `adoService.js`: handles API calls with PAT
+  * `keytar`: store and retrieve PAT securely (session storage fallback in the
+    browser)
+  * Settings screen to input/test PAT
 
 3. **Local Storage**
 

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import StorageService from '../services/storageService';
+import PatService from '../services/patService';
 
 const defaultSettings = {
   startHour: 9,
@@ -19,14 +20,22 @@ export default function useSettings() {
   useEffect(() => {
     const storage = new StorageService('settings', defaultSettings);
     const data = storage.read();
-    if (data) {
-      setSettings({ ...defaultSettings, ...data });
-    }
+    const patService = new PatService();
+    Promise.resolve(patService.get()).then((pat) => {
+      if (data) {
+        setSettings({ ...defaultSettings, ...data, azurePat: pat });
+      } else {
+        setSettings({ ...defaultSettings, azurePat: pat });
+      }
+    });
   }, []);
 
   useEffect(() => {
     const storage = new StorageService('settings');
-    storage.write(settings);
+    const { azurePat, ...persist } = settings;
+    storage.write(persist);
+    const patService = new PatService();
+    patService.set(azurePat);
   }, [settings]);
 
   return { settings, setSettings };

--- a/src/services/patService.js
+++ b/src/services/patService.js
@@ -1,0 +1,45 @@
+// Service to store PAT securely
+let keytar = null;
+try {
+  if (typeof window !== 'undefined' && window.require) {
+    keytar = window.require('keytar');
+  }
+} catch (e) {
+  keytar = null;
+}
+
+export default class PatService {
+  constructor(service = 'calendar-ado', account = 'azure-pat') {
+    this.service = service;
+    this.account = account;
+  }
+
+  async get() {
+    if (keytar) {
+      const res = await keytar.getPassword(this.service, this.account);
+      return res || '';
+    }
+    if (typeof sessionStorage !== 'undefined') {
+      return sessionStorage.getItem(this.account) || '';
+    }
+    return '';
+  }
+
+  async set(pat) {
+    if (keytar) {
+      if (pat) {
+        await keytar.setPassword(this.service, this.account, pat);
+      } else {
+        await keytar.deletePassword(this.service, this.account);
+      }
+      return;
+    }
+    if (typeof sessionStorage !== 'undefined') {
+      if (pat) {
+        sessionStorage.setItem(this.account, pat);
+      } else {
+        sessionStorage.removeItem(this.account);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- avoid persisting the Azure PAT in local storage
- add PatService to store the token via keytar or session storage
- clarify secure PAT handling in the docs

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844a0739c58832382b581a3480ad9e9