### PR TITLE
Fix electron builder config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "main": "src/main/main.js",
+  "build": {
+    "extends": null,
+    "files": [
+      "build/**/*",
+      "src/main/**/*"
+    ]
+  },
   "scripts": {
     "react-start": "react-scripts start",
     "electron": "ELECTRON_START_URL=http://localhost:3000 electron .",


### PR DESCRIPTION
## Summary
- set `extends` to null so electron-builder no longer assumes CRA preset
- include compiled React build and Electron source files for packaging

## Testing
- `npm run electron-pack` *(fails: electron-builder not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a2edeeb08323814a9b7c3f84304b