### PR TITLE
Fix packaging script

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,3 +272,9 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
    npm start
    ```
    This will launch both the React dev server and the Electron shell.
+
+3. Build and package the application:
+   ```bash
+   npm run electron-pack
+   ```
+   This command first builds the React app and then packages the Electron application.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "electron": "ELECTRON_START_URL=http://localhost:3000 electron .",
     "start": "concurrently \"npm run react-start\" \"npm run electron\"",
     "build": "react-scripts build",
-    "electron-pack": "electron-builder"
+    "electron-pack": "npm run build && electron-builder"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- build the React app when running `electron-pack`
- document the packaging step in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a6e6a4d88323ac744626ac9c3dcc