### PR TITLE
Fix Electron preload error

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,5 +1,7 @@
-const { contextBridge, ipcRenderer } = require('electron');
+const { ipcRenderer } = require('electron');
 
-contextBridge.exposeInMainWorld('api', {
+// With contextIsolation disabled we can assign directly to the window
+// object instead of using contextBridge.
+window.api = {
   openWorkItems: (items) => ipcRenderer.send('open-work-items', items),
-});
+};


### PR DESCRIPTION
## Summary
- expose `openWorkItems` on `window` directly instead of using `contextBridge`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68451e9d6f34832390b532334da302dc