### PR TITLE
Persist settings across reinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 * Node.js (Electron main process)
 * Fetch-based ADO API integration with PAT stored securely
 * JSON file-based storage with option to switch to SQLite (`better-sqlite3`)
+  * Files are saved under Electron's `userData` directory so calendar entries
+    and settings survive application reinstalls
 
 **Security**:
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -52,6 +52,10 @@ app.whenReady().then(() => {
     items.forEach(openWorkItemWindow);
   });
 
+  ipcMain.on('get-user-data-path', (event) => {
+    event.returnValue = app.getPath('userData');
+  });
+
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createWindow();

--- a/src/services/storageService.js
+++ b/src/services/storageService.js
@@ -2,14 +2,20 @@
 // Dynamically require Node modules when running in Electron
 let fs = null;
 let path = null;
+let ipcRenderer = null;
+let userDataPath = null;
 try {
   if (typeof window !== 'undefined' && window.require) {
     fs = window.require('fs');
     path = window.require('path');
+    ipcRenderer = window.require('electron').ipcRenderer;
+    userDataPath = ipcRenderer.sendSync('get-user-data-path');
   }
 } catch (e) {
   fs = null;
   path = null;
+  ipcRenderer = null;
+  userDataPath = null;
 }
 
 export default class StorageService {
@@ -17,7 +23,8 @@ export default class StorageService {
     this.storageKey = storageKey;
     this.defaultData = defaultData;
     if (fs && path) {
-      this.dataPath = path.join(process.cwd(), `${storageKey}.json`);
+      const baseDir = userDataPath || process.cwd();
+      this.dataPath = path.join(baseDir, `${storageKey}.json`);
     }
   }
 


### PR DESCRIPTION
## Summary
- store calendar entries and settings under Electron's userData directory
- expose userData path from main process
- document persistent storage location

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845223b2f348323b1b7de70e0eadb7c