### PR TITLE
Fix work item opening

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -22,10 +22,35 @@ function createWindow() {
   }
 }
 
-function openWorkItemWindow({ url }) {
-  // Opening in an external browser avoids issues with Azure DevOps not
-  // rendering correctly inside an Electron BrowserWindow.
+function openWorkItemWindow({ hours, url }) {
+  // Open work item in the user's default browser to avoid rendering issues
+  // inside an Electron BrowserWindow.
   shell.openExternal(url);
+
+  // Show an always-on-top banner window with the suggested hours since we
+  // can no longer inject the banner directly into the ADO page.
+  const bannerWin = new BrowserWindow({
+    width: 420,
+    height: 60,
+    frame: false,
+    resizable: false,
+    movable: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+  });
+
+  const bannerHtml = `<!DOCTYPE html>
+    <html><body style="margin:0;display:flex;align-items:center;justify-content:center;font-family:sans-serif;background:#fffae6;padding:10px;">
+    Suggested hours to log: ${hours.toFixed(2)}
+    </body></html>`;
+
+  bannerWin.loadURL('data:text/html,' + encodeURIComponent(bannerHtml));
+
+  setTimeout(() => {
+    if (!bannerWin.isDestroyed()) {
+      bannerWin.close();
+    }
+  }, 5000);
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- open work items in the user's default browser

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684524dff17883239e1dbc3fdcf421d7