### PR TITLE
Add project filter and fetch recent work items

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,9 +22,11 @@ function App() {
   }, [settings.darkMode]);
 
   useEffect(() => {
-    const service = new AdoService();
+    const { azureOrg, azurePat, azureProjects } = settings;
+    if (!azureOrg || !azurePat) return;
+    const service = new AdoService(azureOrg, azurePat, azureProjects);
     service.getWorkItems().then(setItems);
-  }, [setItems]);
+  }, [settings.azureOrg, settings.azurePat, settings.azureProjects, setItems]);
 
   const getWeekStart = (date) => {
     const d = new Date(date);
@@ -288,7 +290,7 @@ function App() {
             Start Submit Session
           </button>
         </div>
-        <WorkItems items={items} setItems={setItems} />
+        <WorkItems items={items} />
       </div>
     </div>
   );

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -173,6 +173,23 @@ export default function Settings({ settings, setSettings }) {
                       className="border w-full px-1"
                     />
                   </div>
+                  <div>
+                    <label className="mr-1">Projects:</label>
+                    <input
+                      type="text"
+                      value={temp.azureProjects.join(',')}
+                      onChange={(e) =>
+                        setTemp({
+                          ...temp,
+                          azureProjects: e.target.value
+                            .split(',')
+                            .map((p) => p.trim())
+                            .filter(Boolean),
+                        })
+                      }
+                      className="border w-full px-1"
+                    />
+                  </div>
                 </>
               )}
               <div className="flex space-x-2 pt-2">

--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import AdoService from '../services/adoService';
+import React, { useState } from 'react';
 import WorkItem from './WorkItem';
 
 function buildTree(items) {
@@ -31,13 +30,7 @@ function renderTree(nodes, level = 0) {
   });
 }
 
-export default function WorkItems({ items, setItems }) {
-  useEffect(() => {
-    if (items.length === 0) {
-      const service = new AdoService();
-      service.getWorkItems().then(setItems);
-    }
-  }, [items, setItems]);
+export default function WorkItems({ items }) {
 
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState('all');

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -12,6 +12,7 @@ const defaultSettings = {
   darkMode: false,
   azureOrg: '',
   azurePat: '',
+  azureProjects: [],
 };
 
 export default function useSettings() {


### PR DESCRIPTION
## Summary
- extend settings to include `azureProjects`
- let users set projects in Settings
- update `AdoService` to fetch all work items changed in the last 30 days filtered by project
- load items using org, PAT and project settings

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68452b08ce988323950c8cc4856fd6ef