### PR TITLE
Add refresh support for ADO work items

### DIFF
--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -30,7 +30,7 @@ function renderTree(nodes, level = 0) {
   });
 }
 
-export default function WorkItems({ items }) {
+export default function WorkItems({ items, onRefresh }) {
 
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState('all');
@@ -49,7 +49,17 @@ export default function WorkItems({ items }) {
 
   return (
     <div className="mb-4">
-      <h2 className="font-semibold">Work Items</h2>
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="font-semibold">Work Items</h2>
+        {onRefresh && (
+          <button
+            className="px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700"
+            onClick={onRefresh}
+          >
+            Refresh
+          </button>
+        )}
+      </div>
       <div className="flex space-x-2 mb-2">
         <input
           type="text"


### PR DESCRIPTION
## Summary
- fetch Azure work items only once on load
- add a refresh button in the Work Items panel

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845309f67e08323938d15c4a9d5088b