### PR TITLE
Add daily breakdown for suggested log hours

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -245,12 +245,16 @@ function App() {
       if (start >= weekStart && start < weekEnd && b.taskId) {
         const end = new Date(b.end);
         const hours = (end - start) / (1000 * 60 * 60);
-        map[b.taskId] = (map[b.taskId] || 0) + hours;
+        const dayKey = start.toLocaleDateString('en-US', { weekday: 'short', month: 'numeric', day: 'numeric' });
+        if (!map[b.taskId]) map[b.taskId] = { total: 0, days: {} };
+        map[b.taskId].total += hours;
+        map[b.taskId].days[dayKey] = (map[b.taskId].days[dayKey] || 0) + hours;
       }
     });
-    const items = Object.entries(map).map(([id, hours]) => ({
+    const items = Object.entries(map).map(([id, data]) => ({
       id,
-      hours,
+      hours: data.total,
+      days: data.days,
       url: settings.azureOrg
         ? `https://dev.azure.com/${settings.azureOrg}/_workitems/edit/${id}`
         : `https://dev.azure.com/_workitems/edit/${id}`,

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -22,7 +22,7 @@ function createWindow() {
   }
 }
 
-function openWorkItemWindow({ id, hours, url }) {
+function openWorkItemWindow({ id, hours, url, days }) {
   const win = new BrowserWindow({ width: 1000, height: 800 });
   win.loadURL(url);
 
@@ -37,7 +37,17 @@ function openWorkItemWindow({ id, hours, url }) {
       banner.style.background = '#fffae6';
       banner.style.padding = '10px';
       banner.style.textAlign = 'center';
-      banner.textContent = 'Suggested hours to log: ${hours.toFixed(2)}';
+      const header = document.createElement('div');
+      header.textContent = 'Suggested hours to log: ${hours.toFixed(2)}';
+      banner.appendChild(header);
+      const list = document.createElement('ul');
+      const breakdown = ${JSON.stringify(days || {})};
+      Object.entries(breakdown).forEach(([day, hrs]) => {
+        const li = document.createElement('li');
+        li.textContent = `${day}: ${hrs.toFixed(2)}`;
+        list.appendChild(li);
+      });
+      banner.appendChild(list);
       document.body.appendChild(banner);
       document.body.style.marginTop = (banner.offsetHeight + 10) + 'px';
     `;


### PR DESCRIPTION
## Summary
- show hours per day for work items when starting submit session
- display breakdown banner in Electron window

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684538285c1c83239e5ba42ad96378e1