### PR TITLE
Store PAT on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
    ```bash
    npm install
    ```
+   This will also build the native `keytar` module used for secure PAT storage.
 2. Start the application:
    ```bash
    npm start

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1"
+    "react-scripts": "5.0.1",
+    "keytar": "^9.1.2"
   },
   "devDependencies": {
     "concurrently": "^8.0.0",

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import PatService from '../services/patService';
 
 const dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
@@ -21,6 +22,8 @@ export default function Settings({ settings, setSettings }) {
   };
 
   const save = () => {
+    const patService = new PatService();
+    patService.set(temp.azurePat);
     setSettings(temp);
     setOpen(false);
     setNewProject('');


### PR DESCRIPTION
## Summary
- store PAT via PatService on save instead of only via hook
- add keytar dependency for secure token storage
- mention keytar install step in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68453ab218c48323a6a85ba9f7ba287b