### PR TITLE
Set homepage for Electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "calendar-ado",
   "version": "0.1.0",
   "private": true,
+  "homepage": "./",
   "main": "src/main/main.js",
   "build": {
     "extends": null,


### PR DESCRIPTION
## Summary
- add a `homepage` field in package.json so Electron loads app correctly

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453fc107048323b250d2098c8cdee3