### PR TITLE
Add project colors and highlight in calendar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -291,6 +291,7 @@ function App() {
           onDelete={deleteBlock}
           weekStart={weekStart}
           items={items}
+          projectColors={settings.projectColors}
         />
       </div>
       <div className="w-64 pl-4 space-y-4">
@@ -304,7 +305,11 @@ function App() {
             Start Submit Session
           </button>
         </div>
-        <WorkItems items={items} onRefresh={fetchWorkItems} />
+        <WorkItems
+          items={items}
+          onRefresh={fetchWorkItems}
+          projectColors={settings.projectColors}
+        />
       </div>
     </div>
   );

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -10,6 +10,7 @@ export default function Calendar({
   onUpdate,
   onTimeChange,
   items,
+  projectColors = {},
 }) {
   const weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
   const days = settings.workDays;
@@ -361,6 +362,12 @@ export default function Calendar({
                       (startMinutes - settings.startHour * 60) * (hourHeight / 60);
                     const height = (endMinutes - startMinutes) * (hourHeight / 60);
                     const highlight = hoveredId === b.id;
+                    const item = b.itemId
+                      ? findItem(b.itemId)
+                      : b.taskId
+                      ? findItem(b.taskId)
+                      : null;
+                    const projectColor = item ? projectColors[item.project] : null;
                     return (
                       <div
                         key={b.id}
@@ -383,7 +390,11 @@ export default function Calendar({
                           }
                         }}
                         className={`work-block absolute left-0 right-0 p-1 border rounded-md overflow-hidden select-none text-[10px] leading-tight ${b.taskId ? 'bg-blue-200 dark:bg-blue-800 border-blue-300 dark:border-blue-500' : 'bg-gray-100 dark:bg-gray-600 border-gray-300 dark:border-gray-500'} ${b.taskId && b.itemId ? 'border-yellow-400' : ''} ${highlight ? 'ring-2 ring-blue-400' : ''}`}
-                        style={{ top: `${top}px`, height: `${height}px` }}
+                        style={{
+                          top: `${top}px`,
+                          height: `${height}px`,
+                          borderLeft: projectColor ? `4px solid ${projectColor}` : undefined,
+                        }}
                       >
                         <div className="text-[10px]">
                           {(() => {

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -8,6 +8,7 @@ export default function Settings({ settings, setSettings }) {
   const [tab, setTab] = useState('general');
   const [temp, setTemp] = useState(settings);
   const [newProject, setNewProject] = useState('');
+  const [newColor, setNewColor] = useState('#cccccc');
 
   useEffect(() => {
     setTemp(settings);
@@ -27,6 +28,7 @@ export default function Settings({ settings, setSettings }) {
     setSettings(temp);
     setOpen(false);
     setNewProject('');
+    setNewColor('#cccccc');
   };
 
   return (
@@ -187,6 +189,12 @@ export default function Settings({ settings, setSettings }) {
                         onChange={(e) => setNewProject(e.target.value)}
                         className="border flex-grow px-1"
                       />
+                      <input
+                        type="color"
+                        value={newColor}
+                        onChange={(e) => setNewColor(e.target.value)}
+                        className="ml-1"
+                      />
                       <button
                         className="ml-1 px-2 bg-blue-500 text-white"
                         onClick={() => {
@@ -195,8 +203,13 @@ export default function Settings({ settings, setSettings }) {
                             setTemp({
                               ...temp,
                               azureProjects: [...temp.azureProjects, name],
+                              projectColors: {
+                                ...temp.projectColors,
+                                [name]: newColor,
+                              },
                             });
                             setNewProject('');
+                            setNewColor('#cccccc');
                           }
                         }}
                       >
@@ -207,12 +220,29 @@ export default function Settings({ settings, setSettings }) {
                       {temp.azureProjects.map((p, idx) => (
                         <li key={idx} className="flex items-center justify-between border px-1">
                           <span>{p}</span>
+                          <input
+                            type="color"
+                            value={temp.projectColors[p] || '#cccccc'}
+                            onChange={(e) =>
+                              setTemp({
+                                ...temp,
+                                projectColors: {
+                                  ...temp.projectColors,
+                                  [p]: e.target.value,
+                                },
+                              })
+                            }
+                            className="mx-1"
+                          />
                           <button
                             className="text-xs text-red-600"
                             onClick={() =>
                               setTemp({
                                 ...temp,
                                 azureProjects: temp.azureProjects.filter((_, i) => i !== idx),
+                                projectColors: Object.fromEntries(
+                                  Object.entries(temp.projectColors).filter(([key]) => key !== p)
+                                ),
                               })
                             }
                           >
@@ -234,6 +264,7 @@ export default function Settings({ settings, setSettings }) {
                     setTemp(settings);
                     setOpen(false);
                     setNewProject('');
+                    setNewColor('#cccccc');
                   }}
                 >
                   Cancel

--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -30,7 +30,7 @@ function renderTree(nodes, level = 0) {
   });
 }
 
-export default function WorkItems({ items, onRefresh }) {
+export default function WorkItems({ items, onRefresh, projectColors = {} }) {
 
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState('all');
@@ -106,7 +106,8 @@ export default function WorkItems({ items, onRefresh }) {
           return (
             <div key={project}>
               <div
-                className="px-2 py-1 bg-gray-200 dark:bg-gray-700 cursor-pointer font-semibold"
+                className="px-2 py-1 cursor-pointer font-semibold"
+                style={{ backgroundColor: projectColors[project] || undefined }}
                 onClick={() => toggle(project)}
               >
                 {project}

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -13,6 +13,7 @@ const defaultSettings = {
   azureOrg: '',
   azurePat: '',
   azureProjects: [],
+  projectColors: {},
 };
 
 export default function useSettings() {


### PR DESCRIPTION
## Summary
- allow project color settings
- apply project color to collapsible project headers
- show project color as left border highlight on calendar blocks

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684546992f748323bf68146a3854d59c