### PR TITLE
Improve week navigation UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Calendar from './components/Calendar';
 import HoursSummary from './components/HoursSummary';
 import WorkItems from './components/WorkItems';
 import Settings from './components/Settings';
+import YearHint from './components/YearHint';
 import useWorkBlocks from './hooks/useWorkBlocks';
 import useSettings from './hooks/useSettings';
 import useAdoItems from './hooks/useAdoItems';
@@ -270,17 +271,27 @@ function App() {
     <div className="p-4 flex min-h-screen bg-yellow-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
       <div className="flex-grow">
         <h1 className="text-2xl font-bold mb-4">Calendar-Ado MVP</h1>
-        <div className="mb-2 space-x-2">
-          <button className="px-2 py-1 bg-gray-200 dark:bg-gray-700" onClick={prevWeek}>
-            Prev Week
+        <div className="mb-2 flex items-center space-x-2">
+          <button
+            className="px-3 py-1 rounded bg-blue-500 hover:bg-blue-600 text-white"
+            onClick={prevWeek}
+          >
+            ◀ Prev
           </button>
-          <button className="px-2 py-1 bg-gray-200 dark:bg-gray-700" onClick={currentWeek}>
+          <button
+            className="px-3 py-1 rounded bg-blue-500 hover:bg-blue-600 text-white"
+            onClick={currentWeek}
+          >
             This Week
           </button>
-          <button className="px-2 py-1 bg-gray-200 dark:bg-gray-700" onClick={nextWeek}>
-            Next Week
+          <button
+            className="px-3 py-1 rounded bg-blue-500 hover:bg-blue-600 text-white"
+            onClick={nextWeek}
+          >
+            Next ▶
           </button>
-          <span className="ml-2 font-semibold">{formatRange()}</span>
+          <span className="ml-4 font-semibold">{formatRange()}</span>
+          <YearHint weekStart={weekStart} />
         </div>
         <Calendar
           blocks={blocks}

--- a/src/components/YearHint.jsx
+++ b/src/components/YearHint.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useRef } from 'react';
+
+export default function YearHint({ weekStart }) {
+  const containerRef = useRef(null);
+
+  const getWeekNumber = (date) => {
+    const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+    const dayNum = d.getUTCDay() || 7;
+    d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    return Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  };
+
+  const weekNum = getWeekNumber(weekStart);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      const barWidth = 6; // width of each week bar in px
+      containerRef.current.scrollLeft = Math.max(0, weekNum * barWidth - 48);
+    }
+  }, [weekNum]);
+
+  const bars = Array.from({ length: 52 }, (_, i) => (
+    <div
+      key={i}
+      className={`h-full flex-shrink-0 ${i + 1 === weekNum ? 'bg-blue-500' : 'bg-gray-400 dark:bg-gray-600'}`}
+      style={{ width: '6px', marginRight: '1px' }}
+    />
+  ));
+
+  return (
+    <div
+      ref={containerRef}
+      className="overflow-hidden w-32 h-2 ml-4 rounded bg-gray-200 dark:bg-gray-700"
+    >
+      <div className="flex h-full">{bars}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `YearHint` component to show year progress
- style week navigation buttons with new colors
- display a compact scrolling year indicator next to the navigation buttons

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454903b3a883239acfd271e8e8bab0