### PR TITLE
Enhance year minimap with block hints

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -291,7 +291,7 @@ function App() {
             Next ▶
           </button>
           <span className="ml-4 font-semibold">{formatRange()}</span>
-          <YearHint weekStart={weekStart} />
+          <YearHint weekStart={weekStart} blocks={blocks} />
         </div>
         <Calendar
           blocks={blocks}

--- a/src/components/YearHint.jsx
+++ b/src/components/YearHint.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-export default function YearHint({ weekStart }) {
+export default function YearHint({ weekStart, blocks = [] }) {
   const containerRef = useRef(null);
 
   const getWeekNumber = (date) => {
@@ -13,6 +13,14 @@ export default function YearHint({ weekStart }) {
 
   const weekNum = getWeekNumber(weekStart);
 
+  const weekCounts = Array(52).fill(0);
+  blocks.forEach((b) => {
+    if (!b.start) return;
+    const wk = getWeekNumber(new Date(b.start)) - 1;
+    if (wk >= 0 && wk < 52) weekCounts[wk] += 1;
+  });
+  const maxCount = Math.max(...weekCounts, 0);
+
   useEffect(() => {
     if (containerRef.current) {
       const barWidth = 6; // width of each week bar in px
@@ -20,20 +28,30 @@ export default function YearHint({ weekStart }) {
     }
   }, [weekNum]);
 
-  const bars = Array.from({ length: 52 }, (_, i) => (
-    <div
-      key={i}
-      className={`h-full flex-shrink-0 ${i + 1 === weekNum ? 'bg-blue-500' : 'bg-gray-400 dark:bg-gray-600'}`}
-      style={{ width: '6px', marginRight: '1px' }}
-    />
-  ));
+  const bars = Array.from({ length: 52 }, (_, i) => {
+    const intensity = maxCount ? weekCounts[i] / maxCount : 0;
+    const baseColor = i + 1 === weekNum ? 'bg-blue-500' : 'bg-gray-400 dark:bg-gray-600';
+    const style = {
+      width: '6px',
+      marginRight: '1px',
+      opacity: i + 1 === weekNum ? 1 : 0.2 + intensity * 0.8,
+    };
+    return <div key={i} className={`h-full flex-shrink-0 ${baseColor}`} style={style} />;
+  });
 
   return (
     <div
       ref={containerRef}
-      className="overflow-hidden w-32 h-2 ml-4 rounded bg-gray-200 dark:bg-gray-700"
+      className="relative overflow-hidden w-32 h-2 ml-4 rounded bg-gray-200 dark:bg-gray-700"
     >
       <div className="flex h-full">{bars}</div>
+      <div
+        className="absolute top-0 bottom-0 border border-yellow-400 pointer-events-none"
+        style={{
+          left: `${(weekNum - 1) * 7}px`,
+          width: '6px',
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- improve year minimap to show work item density
- add visual highlight overlay for current week
- pass work blocks to YearHint

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454afb40d48323ab23c22bcf05ea55