### PR TITLE
Improve YearHint with full-year mini calendar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -291,7 +291,7 @@ function App() {
             Next ▶
           </button>
           <span className="ml-4 font-semibold">{formatRange()}</span>
-          <YearHint weekStart={weekStart} blocks={blocks} />
+          <YearHint weekStart={weekStart} blocks={blocks} settings={settings} />
         </div>
         <Calendar
           blocks={blocks}

--- a/src/components/YearHint.jsx
+++ b/src/components/YearHint.jsx
@@ -1,57 +1,114 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 
-export default function YearHint({ weekStart, blocks = [] }) {
-  const containerRef = useRef(null);
+export default function YearHint({ weekStart, blocks = [], settings = {} }) {
+  const startHour = settings.startHour ?? 0;
+  const endHour = settings.endHour ?? 24;
+  const hours = endHour - startHour;
 
-  const getWeekNumber = (date) => {
-    const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-    const dayNum = d.getUTCDay() || 7;
-    d.setUTCDate(d.getUTCDate() + 4 - dayNum);
-    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-    return Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  const getWeekStart = (date) => {
+    const d = new Date(date);
+    const day = d.getDay();
+    const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+    d.setDate(diff);
+    d.setHours(0, 0, 0, 0);
+    return d;
   };
 
-  const weekNum = getWeekNumber(weekStart);
+  const firstWeek = getWeekStart(new Date(weekStart.getFullYear(), 0, 1));
+  const weeks = Array.from({ length: 52 }, (_, i) => {
+    const d = new Date(firstWeek);
+    d.setDate(firstWeek.getDate() + i * 7);
+    return d;
+  });
 
-  const weekCounts = Array(52).fill(0);
+  const weekWidth = 14; // px width per week
+  const dayWidth = weekWidth / 7;
+  const hourHeight = 2; // px height per hour
+  const totalHeight = hours * hourHeight;
+
+  const currentIndex = Math.floor(
+    (getWeekStart(weekStart) - firstWeek) / (7 * 24 * 60 * 60 * 1000)
+  );
+
+  const blocksByWeek = {};
   blocks.forEach((b) => {
-    if (!b.start) return;
-    const wk = getWeekNumber(new Date(b.start)) - 1;
-    if (wk >= 0 && wk < 52) weekCounts[wk] += 1;
+    if (!b.start || !b.end) return;
+    const start = new Date(b.start);
+    const end = new Date(b.end);
+    const wIdx = Math.floor(
+      (getWeekStart(start) - firstWeek) / (7 * 24 * 60 * 60 * 1000)
+    );
+    if (wIdx < 0 || wIdx >= 52) return;
+    const dIdx = (start.getDay() + 6) % 7;
+    const startMin =
+      start.getHours() * 60 + start.getMinutes() - startHour * 60;
+    const endMin = end.getHours() * 60 + end.getMinutes() - startHour * 60;
+    if (!blocksByWeek[wIdx]) blocksByWeek[wIdx] = Array.from({ length: 7 }, () => []);
+    blocksByWeek[wIdx][dIdx].push({ start: startMin, end: endMin, taskId: b.taskId });
   });
-  const maxCount = Math.max(...weekCounts, 0);
 
-  useEffect(() => {
-    if (containerRef.current) {
-      const barWidth = 6; // width of each week bar in px
-      containerRef.current.scrollLeft = Math.max(0, weekNum * barWidth - 48);
-    }
-  }, [weekNum]);
-
-  const bars = Array.from({ length: 52 }, (_, i) => {
-    const intensity = maxCount ? weekCounts[i] / maxCount : 0;
-    const baseColor = i + 1 === weekNum ? 'bg-blue-500' : 'bg-gray-400 dark:bg-gray-600';
-    const style = {
-      width: '6px',
-      marginRight: '1px',
-      opacity: i + 1 === weekNum ? 1 : 0.2 + intensity * 0.8,
-    };
-    return <div key={i} className={`h-full flex-shrink-0 ${baseColor}`} style={style} />;
-  });
+  const monthLines = Array.from({ length: 12 }, (_, m) => {
+    const d = new Date(weekStart.getFullYear(), m, 1);
+    const idx = Math.floor(
+      (getWeekStart(d) - firstWeek) / (7 * 24 * 60 * 60 * 1000)
+    );
+    return idx > 0 && idx < 52 ? idx : null;
+  }).filter((i) => i !== null);
 
   return (
-    <div
-      ref={containerRef}
-      className="relative overflow-hidden w-32 h-2 ml-4 rounded bg-gray-200 dark:bg-gray-700"
-    >
-      <div className="flex h-full">{bars}</div>
-      <div
-        className="absolute top-0 bottom-0 border border-yellow-400 pointer-events-none"
-        style={{
-          left: `${(weekNum - 1) * 7}px`,
-          width: '6px',
-        }}
-      />
+    <div className="relative ml-4" style={{ width: weekWidth * 52 + 'px' }}>
+      <svg width={weekWidth * 52} height={totalHeight} className="block">
+        {weeks.map((_, w) => (
+          <g key={w} transform={`translate(${w * weekWidth},0)`}>
+            {Array.from({ length: 7 }, (_, d) => (
+              <rect
+                key={d}
+                x={d * dayWidth}
+                y={0}
+                width={dayWidth}
+                height={totalHeight}
+                fill="none"
+                stroke="#ccc"
+                strokeWidth="0.5"
+              />
+            ))}
+            {blocksByWeek[w] &&
+              blocksByWeek[w].flatMap((dayBlocks, d) =>
+                dayBlocks.map((blk, i) => (
+                  <rect
+                    key={d + '-' + i}
+                    x={d * dayWidth}
+                    y={(blk.start / 60) * hourHeight}
+                    width={dayWidth}
+                    height={((blk.end - blk.start) / 60) * hourHeight}
+                    fill={blk.taskId ? '#60a5fa' : '#cbd5e1'}
+                  />
+                ))
+              )}
+          </g>
+        ))}
+        {monthLines.map((i, idx) => (
+          <line
+            key={idx}
+            x1={i * weekWidth}
+            x2={i * weekWidth}
+            y1={0}
+            y2={totalHeight}
+            stroke="#666"
+            strokeWidth="1"
+          />
+        ))}
+        <rect
+          x={currentIndex * weekWidth}
+          y={0}
+          width={weekWidth}
+          height={totalHeight}
+          fill="none"
+          stroke="#facc15"
+          strokeWidth="2"
+        />
+      </svg>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- show a mini calendar for the whole year in `YearHint`
- highlight current week and show month separators
- pass `settings` to `YearHint` from `App`

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454ce834cc8323a650082a7b25b824