### PR TITLE
Fix minimap jump and add custom CSS vars

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -290,7 +290,7 @@ function App() {
           >
             Next ▶
           </button>
-          <span className="ml-4 font-semibold">{formatRange()}</span>
+          <span className="week-range ml-4 font-semibold">{formatRange()}</span>
           <YearHint weekStart={weekStart} blocks={blocks} settings={settings} />
         </div>
         <Calendar

--- a/src/components/YearHint.jsx
+++ b/src/components/YearHint.jsx
@@ -98,15 +98,19 @@ export default function YearHint({ weekStart, blocks = [], settings = {} }) {
             strokeWidth="1"
           />
         ))}
-        <rect
-          x={currentIndex * weekWidth}
-          y={0}
-          width={weekWidth}
-          height={totalHeight}
-          fill="none"
-          stroke="#facc15"
-          strokeWidth="2"
-        />
+        <g
+          className="minimap-highlight"
+          style={{ transform: `translateX(${currentIndex * weekWidth}px)` }}
+        >
+          <rect
+            x={0}
+            y={0}
+            width={weekWidth}
+            height={totalHeight}
+            fill="none"
+            strokeWidth="2"
+          />
+        </g>
       </svg>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --week-range-width: 9rem;
+  --minimap-highlight-color: #facc15;
+}
+
+.week-range {
+  @apply inline-block w-week-range;
+}
+
+.minimap-highlight {
+  stroke: var(--minimap-highlight-color);
+  @apply transition-transform;
+}
+
 /* modern scrollbars for work item lists */
 .scroll-container {
   scrollbar-width: thin;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,11 @@ module.exports = {
   content: ['./src/**/*.{js,jsx}', './public/index.html'],
   darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      width: {
+        'week-range': 'var(--week-range-width)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- configure Tailwind to expose a custom width based on a CSS variable
- add global CSS variables and helper classes
- keep week range width constant
- animate minimap highlight

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454e8c6f2083239814400ee31a8aa5