### PR TITLE
Fix scroll issue by constraining app dimensions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -268,8 +268,8 @@ function App() {
   };
 
   return (
-    <div className="p-4 flex min-h-screen bg-yellow-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
-      <div className="flex-grow">
+    <div className="p-4 flex h-full w-full overflow-hidden bg-yellow-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
+      <div className="flex flex-col flex-grow overflow-y-auto">
         <h1 className="text-2xl font-bold mb-4">Calendar-Ado MVP</h1>
         <div className="mb-2 flex items-center space-x-2">
           <button className="week-nav-button" onClick={prevWeek}>
@@ -296,7 +296,7 @@ function App() {
           projectColors={settings.projectColors}
         />
       </div>
-      <div className="w-64 pl-4 space-y-4 flex flex-col h-full">
+      <div className="w-64 pl-4 space-y-4 flex flex-col h-full overflow-y-auto">
         <Settings settings={settings} setSettings={setSettings} />
         <HoursSummary blocks={blocks} weekStart={weekStart} />
         <div>

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,15 @@
   --minimap-highlight-color: #facc15;
 }
 
+html,
+body,
+#root {
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  overflow: hidden;
+}
+
 .week-range {
   @apply inline-block w-week-range;
 }


### PR DESCRIPTION
## Summary
- lock body and `#root` to 100vw/100vh
- set root `<App>` container to fill the viewport
- make both main and sidebar areas scroll internally

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455627640883238bdf662cf119bccf