### PR TITLE
Add ADO work item filters to list

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,14 +21,36 @@ function App() {
   const [resizing, setResizing] = useState(false);
 
   const fetchWorkItems = useCallback(() => {
-    const { azureOrg, azurePat, azureProjects } = settings;
+    const {
+      azureOrg,
+      azurePat,
+      azureProjects,
+      azureTags,
+      azureArea,
+      azureIteration,
+    } = settings;
     if (!azureOrg || !azurePat) return;
-    const service = new AdoService(azureOrg, azurePat, azureProjects);
+    const service = new AdoService(
+      azureOrg,
+      azurePat,
+      azureProjects,
+      azureTags,
+      azureArea,
+      azureIteration
+    );
     service.getWorkItems().then((data) => {
       setItems(data);
       setItemsFetched(true);
     });
-  }, [settings.azureOrg, settings.azurePat, settings.azureProjects, setItems]);
+  }, [
+    settings.azureOrg,
+    settings.azurePat,
+    settings.azureProjects,
+    settings.azureTags,
+    settings.azureArea,
+    settings.azureIteration,
+    setItems,
+  ]);
 
   useEffect(() => {
     if (settings.darkMode) {
@@ -47,6 +69,12 @@ function App() {
       fetchWorkItems();
     }
   }, [fetchWorkItems, itemsFetched]);
+
+  useEffect(() => {
+    if (itemsFetched) {
+      fetchWorkItems();
+    }
+  }, [settings.azureTags, settings.azureArea, settings.azureIteration]);
 
   useEffect(() => {
     const handleMove = (e) => {
@@ -354,6 +382,8 @@ function App() {
           items={items}
           onRefresh={fetchWorkItems}
           projectColors={settings.projectColors}
+          settings={settings}
+          setSettings={setSettings}
         />
       </div>
     </div>

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -252,6 +252,45 @@ export default function Settings({ settings, setSettings }) {
                       ))}
                     </ul>
                   </div>
+                  <div>
+                    <label className="mr-1">Tags:</label>
+                    <input
+                      type="text"
+                      value={temp.azureTags.join(', ')}
+                      onChange={(e) =>
+                        setTemp({
+                          ...temp,
+                          azureTags: e.target.value
+                            .split(',')
+                            .map((t) => t.trim())
+                            .filter((t) => t),
+                        })
+                      }
+                      className="border w-full px-1"
+                    />
+                  </div>
+                  <div>
+                    <label className="mr-1">Area Path:</label>
+                    <input
+                      type="text"
+                      value={temp.azureArea}
+                      onChange={(e) =>
+                        setTemp({ ...temp, azureArea: e.target.value })
+                      }
+                      className="border w-full px-1"
+                    />
+                  </div>
+                  <div>
+                    <label className="mr-1">Iteration Path:</label>
+                    <input
+                      type="text"
+                      value={temp.azureIteration}
+                      onChange={(e) =>
+                        setTemp({ ...temp, azureIteration: e.target.value })
+                      }
+                      className="border w-full px-1"
+                    />
+                  </div>
                 </>
               )}
               <div className="flex space-x-2 pt-2">

--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -30,11 +30,20 @@ function renderTree(nodes, level = 0) {
   });
 }
 
-export default function WorkItems({ items, onRefresh, projectColors = {} }) {
+export default function WorkItems({
+  items,
+  onRefresh,
+  projectColors = {},
+  settings,
+  setSettings,
+}) {
 
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState('all');
   const [collapsed, setCollapsed] = useState({});
+
+  const updateSettings = (changes) =>
+    setSettings((prev) => ({ ...prev, ...changes }));
 
   const filtered = items.filter((i) => {
     const matchesSearch = i.title
@@ -73,6 +82,25 @@ export default function WorkItems({ items, onRefresh, projectColors = {} }) {
       return next;
     });
 
+  const handleTags = (e) => {
+    const tags = e.target.value
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t);
+    updateSettings({ azureTags: tags });
+    onRefresh && onRefresh();
+  };
+
+  const handleArea = (e) => {
+    updateSettings({ azureArea: e.target.value });
+    onRefresh && onRefresh();
+  };
+
+  const handleIteration = (e) => {
+    updateSettings({ azureIteration: e.target.value });
+    onRefresh && onRefresh();
+  };
+
   return (
     <div className="mb-4 flex flex-col flex-grow overflow-y-auto min-h-0">
       <div className="flex items-center justify-between mb-1">
@@ -105,6 +133,33 @@ export default function WorkItems({ items, onRefresh, projectColors = {} }) {
           <option value="bug">Bugs</option>
           <option value="task">Tasks</option>
         </select>
+      </div>
+      <div className="flex space-x-2 mb-2">
+        <input
+          type="text"
+          placeholder="Tags"
+          value={settings.azureTags.join(', ')}
+          onChange={handleTags}
+          className="border px-1 text-sm flex-grow"
+        />
+      </div>
+      <div className="flex space-x-2 mb-2">
+        <input
+          type="text"
+          placeholder="Area Path"
+          value={settings.azureArea}
+          onChange={handleArea}
+          className="border px-1 text-sm flex-grow"
+        />
+      </div>
+      <div className="flex space-x-2 mb-2">
+        <input
+          type="text"
+          placeholder="Iteration Path"
+          value={settings.azureIteration}
+          onChange={handleIteration}
+          className="border px-1 text-sm flex-grow"
+        />
       </div>
       <div className="flex-grow overflow-y-auto space-y-2 scroll-container min-h-0">
         {Object.entries(grouped).map(([project, list]) => {

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -14,6 +14,9 @@ const defaultSettings = {
   azurePat: '',
   azureProjects: [],
   projectColors: {},
+  azureTags: [],
+  azureArea: '',
+  azureIteration: '',
   sidebarWidth: 256,
 };
 

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -1,10 +1,20 @@
 import WorkItem from '../models/workItem';
 
 export default class AdoService {
-  constructor(org = '', token = '', projects = []) {
+  constructor(
+    org = '',
+    token = '',
+    projects = [],
+    tags = [],
+    area = '',
+    iteration = ''
+  ) {
     this.org = org;
     this.token = token;
     this.projects = projects;
+    this.tags = tags;
+    this.area = area;
+    this.iteration = iteration;
     this._b64 =
       typeof btoa === 'function'
         ? (str) => btoa(str)
@@ -17,9 +27,21 @@ export default class AdoService {
           .map((p) => `'${p}'`)
           .join(',')}) and `
       : '';
+    const tagFilter = this.tags.length
+      ? this.tags
+          .map((t) => `[System.Tags] CONTAINS '${t}'`)
+          .join(' and ') + ' and '
+      : '';
+    const areaFilter = this.area ? `[System.AreaPath] under '${this.area}' and ` : '';
+    const iterationFilter = this.iteration
+      ? `[System.IterationPath] under '${this.iteration}' and `
+      : '';
     return (
       'Select [System.Id] From WorkItems Where ' +
       projectFilter +
+      tagFilter +
+      areaFilter +
+      iterationFilter +
       '[System.ChangedDate] >= @Today - 30 order by [System.ChangedDate] desc'
     );
   }


### PR DESCRIPTION
## Summary
- expose ADO tag, area and iteration filters in the Work Items pane
- update work item fetching to refresh when those filters change

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455a1a746883239a1af6e8c58af005