### PR TITLE
Implement draggable notes section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,21 +4,38 @@ import HoursSummary from './components/HoursSummary';
 import WorkItems from './components/WorkItems';
 import Settings from './components/Settings';
 import YearHint from './components/YearHint';
+import Notes from './components/Notes';
 import useWorkBlocks from './hooks/useWorkBlocks';
 import useSettings from './hooks/useSettings';
 import useAdoItems from './hooks/useAdoItems';
+import useNotes from './hooks/useNotes';
 import AdoService from './services/adoService';
 
 function App() {
   const { blocks, setBlocks } = useWorkBlocks();
   const { settings, setSettings } = useSettings();
   const { items, setItems } = useAdoItems();
+  const { notes, setNotes, itemNotes, setItemNotes } = useNotes();
   const [itemsFetched, setItemsFetched] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(
     settings.sidebarWidth || 256
   );
   const containerRef = useRef(null);
   const [resizing, setResizing] = useState(false);
+
+  const addNote = (text) =>
+    setNotes((prev) => [...prev, { id: Date.now(), text }]);
+
+  const deleteNote = (id) =>
+    setNotes((prev) => prev.filter((n) => n.id !== id));
+
+  const handleNoteDrop = (itemId, note) => {
+    setItemNotes((prev) => {
+      const list = prev[itemId] ? [...prev[itemId], note.text] : [note.text];
+      return { ...prev, [itemId]: list };
+    });
+    deleteNote(note.id);
+  };
 
   const fetchWorkItems = useCallback(() => {
     const {
@@ -359,6 +376,7 @@ function App() {
           items={items}
           projectColors={settings.projectColors}
         />
+        <Notes notes={notes} onAdd={addNote} onDelete={deleteNote} />
       </div>
       <div
         className="resizer"
@@ -384,6 +402,8 @@ function App() {
           projectColors={settings.projectColors}
           settings={settings}
           setSettings={setSettings}
+          onNoteDrop={handleNoteDrop}
+          itemNotes={itemNotes}
         />
       </div>
     </div>

--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+
+export default function Notes({ notes, onAdd, onDelete }) {
+  const [value, setValue] = useState('');
+
+  const add = () => {
+    const text = value.trim();
+    if (text) {
+      onAdd(text);
+      setValue('');
+    }
+  };
+
+  return (
+    <div className="mt-4 flex flex-col">
+      <h2 className="font-semibold mb-2">Notes</h2>
+      <div className="flex mb-2">
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="border flex-grow px-1 text-sm"
+        />
+        <button
+          className="ml-2 px-2 py-1 bg-blue-500 text-white text-xs"
+          onClick={add}
+        >
+          Add
+        </button>
+      </div>
+      <div className="flex flex-col space-y-1 overflow-y-auto max-h-40">
+        {notes.map((n) => (
+          <div
+            key={n.id}
+            className="p-1 border bg-gray-200 dark:bg-gray-700 text-xs flex justify-between"
+            draggable
+            onDragStart={(e) =>
+              e.dataTransfer.setData('application/x-note', JSON.stringify(n))
+            }
+          >
+            <span className="flex-grow truncate">{n.text}</span>
+            <button
+              className="ml-2 text-red-600 text-xs"
+              onClick={() => onDelete(n.id)}
+            >
+              x
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function WorkItem({ item, level = 0 }) {
+export default function WorkItem({ item, level = 0, notes = [], onNoteDrop }) {
   const colors = {
     task: 'bg-yellow-100 dark:bg-yellow-700',
     'user story': 'bg-blue-100 dark:bg-blue-700',
@@ -18,23 +18,55 @@ export default function WorkItem({ item, level = 0 }) {
     );
   };
 
+  const allowDrop = (e) => {
+    if (e.dataTransfer.types.includes('application/x-note')) {
+      e.preventDefault();
+    }
+  };
+
+  const handleDrop = (e) => {
+    const raw = e.dataTransfer.getData('application/x-note');
+    if (!raw) return;
+    e.preventDefault();
+    const note = JSON.parse(raw);
+    onNoteDrop && onNoteDrop(item.id, note);
+  };
+
   return isFeature ? (
     <div
       className="inline-block rounded-full px-2 py-1 bg-purple-200 dark:bg-purple-700 text-xs font-semibold mr-2 mb-2"
       draggable
       onDragStart={dragStart}
+      onDragOver={allowDrop}
+      onDrop={handleDrop}
     >
       {item.title}
+      {notes.length > 0 && (
+        <ul className="ml-2 list-disc text-[10px]">
+          {notes.map((n, idx) => (
+            <li key={idx}>{n}</li>
+          ))}
+        </ul>
+      )}
     </div>
   ) : (
     <div
       draggable
       onDragStart={dragStart}
+      onDragOver={allowDrop}
+      onDrop={handleDrop}
       className={`p-1 mb-1 border ${colorClass} text-xs truncate`}
       style={{ marginLeft: `${level * 1}rem` }}
     >
       <span className="font-mono mr-1">{item.id}</span>
       {item.title}
+      {notes.length > 0 && (
+        <ul className="ml-4 list-disc text-[10px]">
+          {notes.map((n, idx) => (
+            <li key={idx}>{n}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -17,14 +17,20 @@ function buildTree(items) {
   return roots;
 }
 
-function renderTree(nodes, level = 0) {
+function renderTree(nodes, level = 0, onNoteDrop, notesMap) {
   return nodes.map((node) => {
     const isFeature = node.type?.toLowerCase() === 'feature';
     const containerClass = isFeature ? 'inline-block' : '';
     return (
       <div key={node.id} className={containerClass}>
-        <WorkItem item={node} level={level} />
-        {node.children.length > 0 && renderTree(node.children, level + 1)}
+        <WorkItem
+          item={node}
+          level={level}
+          notes={notesMap[node.id] || []}
+          onNoteDrop={onNoteDrop}
+        />
+        {node.children.length > 0 &&
+          renderTree(node.children, level + 1, onNoteDrop, notesMap)}
       </div>
     );
   });
@@ -36,6 +42,8 @@ export default function WorkItems({
   projectColors = {},
   settings,
   setSettings,
+  onNoteDrop,
+  itemNotes = {},
 }) {
 
   const [search, setSearch] = useState('');
@@ -273,7 +281,7 @@ export default function WorkItems({
               </div>
               {!collapsed[project] && (
                 <div className="mt-1 ml-2 bg-white dark:bg-gray-800 border p-1">
-                  {renderTree(tree)}
+                  {renderTree(tree, 0, onNoteDrop, itemNotes)}
                 </div>
               )}
             </div>

--- a/src/hooks/useNotes.js
+++ b/src/hooks/useNotes.js
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+import StorageService from '../services/storageService';
+
+export default function useNotes() {
+  const [notes, setNotes] = useState([]);
+  const [itemNotes, setItemNotes] = useState({});
+
+  useEffect(() => {
+    const storage = new StorageService('notes', { notes: [], itemNotes: {} });
+    const data = storage.read();
+    setNotes(data.notes || []);
+    setItemNotes(data.itemNotes || {});
+  }, []);
+
+  useEffect(() => {
+    const storage = new StorageService('notes');
+    storage.write({ notes, itemNotes });
+  }, [notes, itemNotes]);
+
+  return { notes, setNotes, itemNotes, setItemNotes };
+}


### PR DESCRIPTION
## Summary
- add a new Notes component for creating and dragging notes
- persist notes and per-work-item notes via new `useNotes` hook
- allow dropping notes onto WorkItems
- show notes attached to each WorkItem

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456137ad988323af351e7dbbde7354