### PR TITLE
Add status grouping for work items

### DIFF
--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -94,9 +94,11 @@ export default function WorkItems({
   });
 
   const grouped = filtered.reduce((acc, item) => {
-    const key = item.project || 'Unknown';
-    if (!acc[key]) acc[key] = [];
-    acc[key].push(item);
+    const projectKey = item.project || 'Unknown';
+    const stateKey = item.state || 'Unknown';
+    if (!acc[projectKey]) acc[projectKey] = {};
+    if (!acc[projectKey][stateKey]) acc[projectKey][stateKey] = [];
+    acc[projectKey][stateKey].push(item);
     return acc;
   }, {});
 
@@ -327,8 +329,7 @@ export default function WorkItems({
         )}
       </div>
       <div className="flex-grow overflow-y-auto space-y-2 scroll-container min-h-0">
-        {Object.entries(grouped).map(([project, list]) => {
-          const tree = buildTree(list);
+        {Object.entries(grouped).map(([project, states]) => {
           const allowGroupDrop = (e) => {
             if (e.dataTransfer.types.includes('application/x-note')) {
               e.preventDefault();
@@ -339,7 +340,9 @@ export default function WorkItems({
             if (!raw) return;
             e.preventDefault();
             const note = JSON.parse(raw);
-            const first = tree[0];
+            const firstState = Object.values(states)[0] || [];
+            const firstTree = buildTree(firstState);
+            const first = firstTree[0];
             if (first) {
               onNoteDrop && onNoteDrop(first.id, note);
             }
@@ -359,7 +362,15 @@ export default function WorkItems({
                   onDragOver={allowGroupDrop}
                   onDrop={handleGroupDrop}
                 >
-                  {renderTree(tree, 0, onNoteDrop, itemNotes)}
+                  {Object.entries(states).map(([state, list]) => {
+                    const tree = buildTree(list);
+                    return (
+                      <div key={state} className="mb-2">
+                        <div className="font-semibold italic">{state}</div>
+                        {renderTree(tree, 0, onNoteDrop, itemNotes)}
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>

--- a/src/models/workItem.js
+++ b/src/models/workItem.js
@@ -8,6 +8,7 @@ export default class WorkItem {
     tags = [],
     area = '',
     iteration = '',
+    state = '',
   }) {
     this.id = id;
     this.title = title;
@@ -17,5 +18,6 @@ export default class WorkItem {
     this.tags = tags;
     this.area = area;
     this.iteration = iteration;
+    this.state = state;
   }
 }

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -49,7 +49,7 @@ export default class AdoService {
   async _fetchItems(ids, auth) {
     const batch = ids.join(',');
     const res = await fetch(
-      `https://dev.azure.com/${this.org}/_apis/wit/workitems?ids=${batch}&fields=System.Id,System.Title,System.WorkItemType,System.Parent,System.TeamProject,System.Tags,System.AreaPath,System.IterationPath&api-version=7.0`,
+      `https://dev.azure.com/${this.org}/_apis/wit/workitems?ids=${batch}&fields=System.Id,System.Title,System.WorkItemType,System.Parent,System.TeamProject,System.Tags,System.AreaPath,System.IterationPath,System.State&api-version=7.0`,
       {
         headers: { Authorization: auth },
       }
@@ -74,6 +74,7 @@ export default class AdoService {
             : [],
           area: d.fields['System.AreaPath'] || '',
           iteration: d.fields['System.IterationPath'] || '',
+          state: d.fields['System.State'] || '',
         })
     );
   }


### PR DESCRIPTION
## Summary
- extend `WorkItem` model with a `state` field
- include `System.State` in ADO work item fetch
- group work items by project and status in the UI

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456570abf48323b2c921226c4c09db