### PR TITLE
Add state order preference and refine grouping

### DIFF
--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -291,6 +291,23 @@ export default function Settings({ settings, setSettings }) {
                       className="border w-full px-1"
                     />
                   </div>
+                  <div>
+                    <label className="mr-1">State Order:</label>
+                    <input
+                      type="text"
+                      value={temp.stateOrder.join(', ')}
+                      onChange={(e) =>
+                        setTemp({
+                          ...temp,
+                          stateOrder: e.target.value
+                            .split(',')
+                            .map((s) => s.trim())
+                            .filter((s) => s),
+                        })
+                      }
+                      className="border w-full px-1"
+                    />
+                  </div>
                 </>
               )}
               <div className="flex space-x-2 pt-2">

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -18,6 +18,14 @@ const defaultSettings = {
   azureArea: '',
   azureIteration: '',
   sidebarWidth: 256,
+  stateOrder: [
+    'New',
+    'Ready',
+    'Active',
+    'Installed in Test',
+    'Verified',
+    'Closed',
+  ],
 };
 
 export default function useSettings() {


### PR DESCRIPTION
## Summary
- add `stateOrder` setting with default New → Closed order
- allow editing state order in settings
- group work items by status of task parents
- display states according to user-defined order

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68456cbe0c148323a09b60fe326890be