### PR TITLE
Add Jest tests for time adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,3 +281,9 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
    npm run electron-pack
    ```
    This command first builds the React app and then packages the Electron application.
+
+4. Run the unit tests:
+   ```bash
+   npm test
+   ```
+   Executes the Jest test suite.

--- a/__tests__/timeAdjust.test.js
+++ b/__tests__/timeAdjust.test.js
@@ -1,0 +1,58 @@
+const {
+  trimLunchOverlap,
+  adjustForOverlap,
+} = require('../src/utils/timeAdjust');
+
+describe('trimLunchOverlap', () => {
+  const settings = { lunchStart: 12, lunchEnd: 13 };
+
+  test('trims block overlapping lunch start', () => {
+    const block = {
+      start: '2023-01-01T11:30:00.000Z',
+      end: '2023-01-01T12:30:00.000Z',
+    };
+    const result = trimLunchOverlap(block, settings);
+    expect(result.start).toBe(block.start);
+    expect(result.end).toBe('2023-01-01T12:00:00.000Z');
+  });
+
+  test('returns null when entirely within lunch', () => {
+    const block = {
+      start: '2023-01-01T12:10:00.000Z',
+      end: '2023-01-01T12:50:00.000Z',
+    };
+    expect(trimLunchOverlap(block, settings)).toBeNull();
+  });
+});
+
+describe('adjustForOverlap', () => {
+  const existing = [
+    { start: '2023-01-01T13:00:00.000Z', end: '2023-01-01T14:00:00.000Z' },
+  ];
+
+  test('trims overlapping end', () => {
+    const block = {
+      start: '2023-01-01T12:30:00.000Z',
+      end: '2023-01-01T13:30:00.000Z',
+    };
+    const result = adjustForOverlap(existing, block);
+    expect(result.end).toBe('2023-01-01T13:00:00.000Z');
+  });
+
+  test('moves start past existing block', () => {
+    const block = {
+      start: '2023-01-01T13:30:00.000Z',
+      end: '2023-01-01T14:30:00.000Z',
+    };
+    const result = adjustForOverlap(existing, block);
+    expect(result.start).toBe('2023-01-01T14:00:00.000Z');
+  });
+
+  test('returns null when inside another block', () => {
+    const block = {
+      start: '2023-01-01T13:15:00.000Z',
+      end: '2023-01-01T13:45:00.000Z',
+    };
+    expect(adjustForOverlap(existing, block)).toBeNull();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "electron": "ELECTRON_START_URL=http://localhost:3000 electron .",
     "start": "concurrently \"npm run react-start\" \"npm run electron\"",
     "build": "react-scripts build",
-    "electron-pack": "npm run build && electron-builder"
+    "electron-pack": "npm run build && electron-builder",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -30,6 +31,10 @@
     "electron-builder": "^24.0.0",
     "tailwindcss": "^3.4.0",
     "postcss": "^8.4.0",
-    "autoprefixer": "^10.4.0"
+    "autoprefixer": "^10.4.0",
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/src/utils/timeAdjust.js
+++ b/src/utils/timeAdjust.js
@@ -1,0 +1,77 @@
+export function isOverlappingLunch(block, settings) {
+  const start = new Date(block.start);
+  const end = new Date(block.end);
+  const lunchStart = new Date(start);
+  lunchStart.setHours(settings.lunchStart, 0, 0, 0);
+  const lunchEnd = new Date(start);
+  lunchEnd.setHours(settings.lunchEnd, 0, 0, 0);
+  return start < lunchEnd && end > lunchStart;
+}
+
+export function trimLunchOverlap(block, settings) {
+  if (!isOverlappingLunch(block, settings)) return block;
+  const start = new Date(block.start);
+  const end = new Date(block.end);
+  const lunchStart = new Date(start);
+  lunchStart.setHours(settings.lunchStart, 0, 0, 0);
+  const lunchEnd = new Date(start);
+  lunchEnd.setHours(settings.lunchEnd, 0, 0, 0);
+
+  if (start >= lunchStart && end <= lunchEnd) {
+    return null;
+  }
+
+  if (start < lunchStart && end > lunchStart && end <= lunchEnd) {
+    end.setTime(lunchStart.getTime());
+  } else if (start >= lunchStart && start < lunchEnd && end > lunchEnd) {
+    start.setTime(lunchEnd.getTime());
+  } else if (start < lunchStart && end > lunchEnd) {
+    const before = lunchStart - start;
+    const after = end - lunchEnd;
+    if (before >= after) {
+      end.setTime(lunchStart.getTime());
+    } else {
+      start.setTime(lunchEnd.getTime());
+    }
+  }
+
+  if (end <= start) return null;
+
+  return { ...block, start: start.toISOString(), end: end.toISOString() };
+}
+
+export function hasOverlap(blocks, newBlock) {
+  const newStart = new Date(newBlock.start);
+  const newEnd = new Date(newBlock.end);
+  return blocks.some((b) => {
+    const start = new Date(b.start);
+    const end = new Date(b.end);
+    return newStart < end && newEnd > start;
+  });
+}
+
+export function adjustForOverlap(blocks, newBlock) {
+  let start = new Date(newBlock.start);
+  let end = new Date(newBlock.end);
+
+  const sorted = [...blocks].sort((a, b) => new Date(a.start) - new Date(b.start));
+
+  for (const b of sorted) {
+    const bStart = new Date(b.start);
+    const bEnd = new Date(b.end);
+
+    if (end > bStart && start < bEnd) {
+      if (start < bStart) {
+        end = new Date(Math.min(end, bStart));
+      } else {
+        start = new Date(Math.max(start, bEnd));
+      }
+    }
+  }
+
+  if (end <= start) {
+    return null;
+  }
+
+  return { ...newBlock, start: start.toISOString(), end: end.toISOString() };
+}


### PR DESCRIPTION
## Summary
- add Jest config and test script
- move time adjustment helpers to `src/utils`
- add unit tests for lunch overlap and block collisions
- document `npm test` in README

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_684572e1ebdc832399d9b9c0ff0eb51b