### PR TITLE
Enable Electron context isolation

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -6,8 +6,8 @@ function createWindow() {
     width: 800,
     height: 600,
     webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false,
+      nodeIntegration: false,
+      contextIsolation: true,
       preload: path.join(__dirname, 'preload.js'),
     },
   });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,7 +1,5 @@
-const { ipcRenderer } = require('electron');
+const { contextBridge, ipcRenderer } = require('electron');
 
-// With contextIsolation disabled we can assign directly to the window
-// object instead of using contextBridge.
-window.api = {
+contextBridge.exposeInMainWorld('api', {
   openWorkItems: (items) => ipcRenderer.send('open-work-items', items),
-};
+});


### PR DESCRIPTION
## Summary
- secure BrowserWindow by enabling context isolation
- update preload to expose `openWorkItems` via `contextBridge`

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684572d5a418832387f60cdef0cd206b