### PR TITLE
Fix PAT saving via keytar bridge

### DIFF
--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,5 +1,11 @@
 const { contextBridge, ipcRenderer } = require('electron');
+const keytar = require('keytar');
 
 contextBridge.exposeInMainWorld('api', {
   openWorkItems: (items) => ipcRenderer.send('open-work-items', items),
+  getPassword: (service, account) => keytar.getPassword(service, account),
+  setPassword: (service, account, password) =>
+    keytar.setPassword(service, account, password),
+  deletePassword: (service, account) =>
+    keytar.deletePassword(service, account),
 });

--- a/src/services/patService.js
+++ b/src/services/patService.js
@@ -1,8 +1,21 @@
 // Service to store PAT securely
 let keytar = null;
 try {
-  if (typeof window !== 'undefined' && window.require) {
-    keytar = window.require('keytar');
+  if (typeof window !== 'undefined') {
+    if (window.api && window.api.getPassword) {
+      // Access to keytar via context bridge
+      keytar = {
+        getPassword: window.api.getPassword,
+        setPassword: window.api.setPassword,
+        deletePassword: window.api.deletePassword,
+      };
+    } else if (window.require) {
+      // Fallback when nodeIntegration is enabled
+      keytar = window.require('keytar');
+    }
+  } else if (typeof require !== 'undefined') {
+    // Node environment (tests)
+    keytar = require('keytar');
   }
 } catch (e) {
   keytar = null;


### PR DESCRIPTION
## Summary
- expose keytar methods through `preload.js`
- use the bridged functions in `patService`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457a9af4d8832384f0492c5b6940fb