### PR TITLE
Fix keytar install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
    npm install
    ```
    This will also build the native `keytar` module used for secure PAT storage.
+   A postinstall script runs `electron-builder install-app-deps` to ensure
+   native modules like `keytar` are rebuilt for the Electron version.
 2. Start the application:
    ```bash
    npm start

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
   "scripts": {
     "react-start": "react-scripts start",
     "electron": "ELECTRON_START_URL=http://localhost:3000 electron .",
-    "start": "concurrently \"npm run react-start\" \"npm run electron\"",
-    "build": "react-scripts build",
-    "electron-pack": "npm run build && electron-builder",
-    "test": "jest"
+  "start": "concurrently \"npm run react-start\" \"npm run electron\"",
+  "build": "react-scripts build",
+  "electron-pack": "npm run build && electron-builder",
+    "test": "jest",
+    "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- rebuild native dependencies like keytar on `npm install`
- document the new postinstall step in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68457e4bfc4c83239078239672f1c230