### PR TITLE
Fix packaging to include keytar

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "extends": null,
     "files": [
       "build/**/*",
-      "src/main/**/*"
+      "src/main/**/*",
+      "node_modules/**/*",
+      "package.json"
     ]
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- include `node_modules` in the Electron build files so native deps like keytar are bundled

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684581230cf88323a5437c32cb5b0aa3