### PR TITLE
Fix PAT persistence

### DIFF
--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -31,6 +31,7 @@ const defaultSettings = {
 
 export default function useSettings() {
   const [settings, setSettings] = useState(defaultSettings);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     const storage = new StorageService('settings', defaultSettings);
@@ -42,16 +43,18 @@ export default function useSettings() {
       } else {
         setSettings({ ...defaultSettings, azurePat: pat });
       }
+      setLoaded(true);
     });
   }, []);
 
   useEffect(() => {
+    if (!loaded) return;
     const storage = new StorageService('settings');
     const { azurePat, ...persist } = settings;
     storage.write(persist);
     const patService = new PatService();
     patService.set(azurePat);
-  }, [settings]);
+  }, [settings, loaded]);
 
   return { settings, setSettings };
 }


### PR DESCRIPTION
## Summary
- preserve saved PAT by waiting until settings load before writing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458df3e72483238f4ed5440d53067b