### PR TITLE
Ignore toggle filters when search text is used

### DIFF
--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -70,15 +70,20 @@ export default function WorkItems({
     const matchesType =
       typeFilter === 'all' || i.type?.toLowerCase() === typeFilter;
 
+    const ignoreToggles = search.trim() !== '';
+
     const matchesTags =
+      ignoreToggles ||
       settings.azureTags.length === 0 ||
       settings.azureTags.every((t) => (i.tags || []).includes(t));
 
     const matchesArea =
+      ignoreToggles ||
       !settings.azureArea ||
       (i.area || '').toLowerCase().startsWith(settings.azureArea.toLowerCase());
 
     const matchesIteration =
+      ignoreToggles ||
       !settings.azureIteration ||
       (i.iteration || '')
         .toLowerCase()


### PR DESCRIPTION
## Summary
- ignore tag, area and iteration filters when searching by text

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459ff928b4832396192f0a98f5c968