### PR TITLE
Implement comment pills for calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 3. Drags on calendar to create a shell block.
 4. System suggests work items; user confirms or drags a task manually.
 5. User can click a task to auto-link it to selected time block.
-6. Notes can be added per block.
+6. Notes appear as draggable comment pills that can be dropped into work blocks.
 
 ### 4.2 Review & Submit
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,17 @@ function App() {
     deleteNote(note.id);
   };
 
+  const handleBlockCommentDrop = (blockId, note) => {
+    setBlocks((prev) =>
+      prev.map((b) =>
+        b.id === blockId
+          ? { ...b, comments: [...(b.comments || []), note.text] }
+          : b
+      )
+    );
+    deleteNote(note.id);
+  };
+
   const fetchWorkItems = useCallback(() => {
     const {
       azureOrg,
@@ -310,6 +321,7 @@ function App() {
           weekStart={weekStart}
           items={items}
           projectColors={settings.projectColors}
+          onCommentDrop={handleBlockCommentDrop}
         />
         <Notes notes={notes} onAdd={addNote} onDelete={deleteNote} />
       </div>

--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -28,19 +28,19 @@ export default function Notes({ notes, onAdd, onDelete }) {
           Add
         </button>
       </div>
-      <div className="flex flex-col space-y-1 overflow-y-auto max-h-40">
+      <div className="flex flex-wrap gap-1 overflow-y-auto max-h-40">
         {notes.map((n) => (
           <div
             key={n.id}
-            className="p-1 border bg-gray-200 dark:bg-gray-700 text-xs flex justify-between"
+            className="px-2 py-1 border rounded-full bg-gray-200 dark:bg-gray-700 text-xs flex items-center"
             draggable
             onDragStart={(e) =>
               e.dataTransfer.setData('application/x-note', JSON.stringify(n))
             }
           >
-            <span className="flex-grow truncate">{n.text}</span>
+            <span className="truncate mr-1">{n.text}</span>
             <button
-              className="ml-2 text-red-600 text-xs"
+              className="ml-auto text-red-600 text-xs"
               onClick={() => onDelete(n.id)}
             >
               x


### PR DESCRIPTION
## Summary
- style notes as draggable comment pills
- allow dropping comment pills onto work blocks
- store comments with work blocks
- pass comment drop handler into calendar
- document comment pill feature in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a0512db48323bec5d3d71e3f369a