### PR TITLE
Enable adding notes with Enter key

### DIFF
--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -19,6 +19,7 @@ export default function Notes({ notes, onAdd, onDelete }) {
           type="text"
           value={value}
           onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && add()}
           className="border flex-grow px-1 text-sm"
         />
         <button


### PR DESCRIPTION
## Summary
- allow submitting notes by pressing Enter in the Notes input field

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a32ae0d883239b957bd382f46ba7