### PR TITLE
Show area path and misconfig stats

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -298,18 +298,25 @@ function App() {
         map[b.taskId].days[dayKey] = (map[b.taskId].days[dayKey] || 0) + hours;
       }
     });
-    const items = Object.entries(map).map(([id, data]) => ({
-      id,
-      hours: data.total,
-      days: data.days,
-      url: settings.azureOrg
-        ? `https://dev.azure.com/${settings.azureOrg}/_workitems/edit/${id}`
-        : `https://dev.azure.com/_workitems/edit/${id}`,
-    }));
+    const itemsToOpen = Object.entries(map).map(([id, data]) => {
+      const task = items.find((it) => it.id === id) || {};
+      const message = !task.area
+        ? `Please assign area path ${settings.azureArea || '(set area path)'} before logging time.`
+        : '';
+      return {
+        id,
+        hours: data.total,
+        days: data.days,
+        url: settings.azureOrg
+          ? `https://dev.azure.com/${settings.azureOrg}/_workitems/edit/${id}`
+          : `https://dev.azure.com/_workitems/edit/${id}`,
+        message,
+      };
+    });
     if (window.api && window.api.openWorkItems) {
-      window.api.openWorkItems(items);
+      window.api.openWorkItems(itemsToOpen);
     } else {
-      items.forEach((i) => window.open(i.url, '_blank'));
+      itemsToOpen.forEach((i) => window.open(i.url, '_blank'));
     }
   };
 
@@ -361,7 +368,7 @@ function App() {
         style={{ width: sidebarWidth }}
       >
         <Settings settings={settings} setSettings={setSettings} />
-        <HoursSummary blocks={blocks} weekStart={weekStart} />
+        <HoursSummary blocks={blocks} weekStart={weekStart} items={items} />
         <div>
           <button
             className="w-full px-2 py-1 bg-green-600 text-white"

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -598,16 +598,16 @@ export default function Calendar({
                             if (item) {
                               return (
                                 <div className="flex flex-col gap-1">
-                                  <ItemBubble item={item} full />
+                                  <ItemBubble item={item} full showArea />
                                   {hasParent && (
                                     <div className="pl-2">
-                                      <ItemBubble item={task} />
+                                      <ItemBubble item={task} showArea />
                                     </div>
                                   )}
                                 </div>
                               );
                             }
-                            return task ? <ItemBubble item={task} /> : null;
+                            return task ? <ItemBubble item={task} showArea /> : null;
                           })()}
                           {!b.itemId && b.workItem && (
                             <span className="bg-gray-200 dark:bg-gray-700 rounded px-1">

--- a/src/components/HoursSummary.jsx
+++ b/src/components/HoursSummary.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function HoursSummary({ blocks, weekStart }) {
+export default function HoursSummary({ blocks, weekStart, items }) {
   const weekEnd = new Date(weekStart);
   weekEnd.setDate(weekStart.getDate() + 7);
 
@@ -27,6 +27,20 @@ export default function HoursSummary({ blocks, weekStart }) {
       const diff = (end - start) / (1000 * 60 * 60);
       return sum + diff;
     }, 0);
+
+  const misconfiguredHours = blocks
+    .filter((b) => {
+      const start = new Date(b.start);
+      if (!(start >= weekStart && start < weekEnd && b.taskId)) return false;
+      const task = items?.find((i) => i.id === b.taskId);
+      return !task || !task.area;
+    })
+    .reduce((sum, b) => {
+      const start = new Date(b.start);
+      const end = new Date(b.end);
+      const diff = (end - start) / (1000 * 60 * 60);
+      return sum + diff;
+    }, 0);
   const overLimit = totalHours > 40;
   const textColor = overLimit ? 'text-red-600' : 'text-gray-800 dark:text-gray-200';
 
@@ -36,6 +50,8 @@ export default function HoursSummary({ blocks, weekStart }) {
       <span className={`${textColor} font-bold`}>{totalHours.toFixed(2)}</span>
       <span className="font-semibold ml-2">Assigned: </span>
       <span className="font-bold">{assignedHours.toFixed(2)}</span>
+      <span className="font-semibold ml-2">Wrong Config: </span>
+      <span className="font-bold">{misconfiguredHours.toFixed(2)}</span>
     </div>
   );
 }

--- a/src/components/ItemBubble.jsx
+++ b/src/components/ItemBubble.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function ItemBubble({ item, full = false }) {
+export default function ItemBubble({ item, full = false, showArea = false }) {
   if (!item) return null;
   const colors = {
     task: 'bg-yellow-200 dark:bg-yellow-700',
@@ -11,10 +11,11 @@ export default function ItemBubble({ item, full = false }) {
   const colorClass = colors[item.type?.toLowerCase()] || 'bg-gray-200 dark:bg-gray-700';
   const displayClass = full ? 'block w-full text-center' : 'inline-block';
   return (
-    <span
-      className={`${displayClass} rounded-full px-2 py-1 text-xs font-semibold ${colorClass}`}
-    >
-      {item.title}
-    </span>
+    <div className={`${displayClass} rounded-full px-2 py-1 text-xs font-semibold ${colorClass}`}> 
+      <div>{item.title}</div>
+      {showArea && item.area && (
+        <div className="text-[9px] mt-0.5">{item.area}</div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- display area path with work items in calendar blocks
- warn about missing area path when starting submit session
- track misconfigured hours in summary

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ad2c893c8323af01c7e88c441e9d