### PR TITLE
Add lockable calendar days

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import useWorkBlocks from './hooks/useWorkBlocks';
 import useSettings from './hooks/useSettings';
 import useAdoItems from './hooks/useAdoItems';
 import useNotes from './hooks/useNotes';
+import useDayLocks from './hooks/useDayLocks';
 import AdoService from './services/adoService';
 import {
   trimLunchOverlap,
@@ -22,6 +23,7 @@ function App() {
   const { settings, setSettings } = useSettings();
   const { items, setItems } = useAdoItems();
   const { notes, setNotes, itemNotes, setItemNotes } = useNotes();
+  const { lockedDays, setLockedDays } = useDayLocks();
   const [itemsFetched, setItemsFetched] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(
     settings.sidebarWidth || 256
@@ -349,6 +351,8 @@ function App() {
           items={items}
           projectColors={settings.projectColors}
           onCommentDrop={handleBlockCommentDrop}
+          lockedDays={lockedDays}
+          setLockedDays={setLockedDays}
         />
         <Notes notes={notes} onAdd={addNote} onDelete={deleteNote} />
       </div>

--- a/src/hooks/useDayLocks.js
+++ b/src/hooks/useDayLocks.js
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+import StorageService from '../services/storageService';
+
+export default function useDayLocks() {
+  const [lockedDays, setLockedDays] = useState({});
+
+  useEffect(() => {
+    const storage = new StorageService('lockedDays', { lockedDays: {} });
+    const data = storage.read();
+    setLockedDays(data.lockedDays || {});
+  }, []);
+
+  useEffect(() => {
+    const storage = new StorageService('lockedDays');
+    storage.write({ lockedDays });
+  }, [lockedDays]);
+
+  return { lockedDays, setLockedDays };
+}


### PR DESCRIPTION
## Summary
- add `useDayLocks` hook for persisting locked days
- wire day locks through `App` into `Calendar`
- show a lock toggle when hovering over a day column
- disable editing work blocks on locked days

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ade2aa50832383ff4c4ecbd46d5b