### PR TITLE
Refine work block UI styling

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -618,11 +618,12 @@ export default function Calendar({
                             e.currentTarget.style.cursor = 'move';
                           }
                         }}
-                        className={`work-block absolute left-0 right-0 p-1 border rounded-md overflow-hidden select-none text-[10px] leading-tight ${b.taskId ? 'bg-blue-200 dark:bg-blue-800 border-blue-300 dark:border-blue-500' : 'bg-gray-100 dark:bg-gray-600 border-gray-300 dark:border-gray-500'} ${b.taskId && b.itemId ? 'border-yellow-400' : ''} ${highlight ? 'ring-2 ring-blue-400' : ''}`}
+                        className={`work-block absolute left-0 right-0 p-1 border rounded-md overflow-hidden select-none text-[10px] leading-tight ${b.taskId ? 'border-gray-300 dark:border-gray-500' : 'bg-gray-100 dark:bg-gray-600 border-gray-300 dark:border-gray-500'} ${b.taskId && b.itemId ? 'border-yellow-400' : ''} ${highlight ? 'ring-2 ring-blue-400' : ''}`}
                         style={{
                           top: `${top}px`,
                           height: `${height}px`,
                           borderLeft: projectColor ? `4px solid ${projectColor}` : undefined,
+                          backgroundColor: b.taskId ? projectColor || '#e5e7eb' : undefined,
                         }}
                       >
                         <div className="text-[10px]">
@@ -672,7 +673,7 @@ export default function Calendar({
                             return task ? <ItemBubble item={task} showArea /> : null;
                           })()}
                           {!b.itemId && b.workItem && (
-                            <span className="bg-gray-200 dark:bg-gray-700 rounded px-1">
+                            <span className="px-1 italic">
                               {b.workItem}
                             </span>
                           )}
@@ -680,10 +681,7 @@ export default function Calendar({
                           {b.comments && b.comments.length > 0 && (
                             <div className="flex flex-wrap gap-1 mt-1">
                               {b.comments.map((c, idx) => (
-                                <span
-                                  key={idx}
-                                  className="bg-gray-200 dark:bg-gray-700 rounded-full px-1"
-                                >
+                                <span key={idx} className="border px-0.5 text-[9px]">
                                   {c}
                                 </span>
                               ))}

--- a/src/components/ItemBubble.jsx
+++ b/src/components/ItemBubble.jsx
@@ -3,16 +3,16 @@ import React from 'react';
 export default function ItemBubble({ item, full = false, showArea = false }) {
   if (!item) return null;
   const colors = {
-    task: 'bg-yellow-200 dark:bg-yellow-700',
-    'user story': 'bg-blue-200 dark:bg-blue-700',
-    bug: 'bg-red-200 dark:bg-red-700',
-    feature: 'bg-purple-200 dark:bg-purple-700',
+    task: 'border-yellow-400',
+    'user story': 'border-blue-400',
+    bug: 'border-red-400',
+    feature: 'border-purple-400',
   };
-  const colorClass = colors[item.type?.toLowerCase()] || 'bg-gray-200 dark:bg-gray-700';
-  const displayClass = full ? 'block w-full text-center' : 'inline-block';
+  const colorClass = colors[item.type?.toLowerCase()] || 'border-gray-400';
+  const displayClass = full ? 'block w-full' : 'block';
   return (
-    <div className={`${displayClass} rounded-full px-2 py-1 text-xs font-semibold ${colorClass}`}> 
-      <div>{item.title}</div>
+    <div className={`${displayClass} pl-1 border-l-4 ${colorClass} text-xs`}>
+      <div className="font-medium">{item.title}</div>
       {showArea && item.area && (
         <div className="text-[9px] mt-0.5">{item.area}</div>
       )}


### PR DESCRIPTION
## Summary
- update `ItemBubble` for minimal look using left border
- style work blocks with project color backgrounds
- remove pill backgrounds from text details in calendar

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b239699883238fa9fd1f041e9775