### PR TITLE
UI modernizations

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,10 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
+    rel="stylesheet"
+  />
   <link rel="icon" href="%PUBLIC_URL%/icon.png" />
   <title>Calendar ADO</title>
 </head>
-<body class="bg-yellow-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
+<body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
   <div id="root"></div>
 </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -325,7 +325,7 @@ function App() {
   return (
     <div
       ref={containerRef}
-      className="p-4 flex h-full w-full overflow-hidden bg-yellow-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100"
+      className="p-6 flex gap-4 h-full w-full overflow-hidden bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100"
     >
       <div className="flex flex-col flex-grow overflow-y-auto">
         {showReminder && (
@@ -368,7 +368,7 @@ function App() {
         onMouseDown={() => setResizing(true)}
       />
       <div
-        className="pl-4 space-y-4 flex flex-col h-full overflow-y-auto"
+        className="pl-6 space-y-4 flex flex-col h-full overflow-y-auto bg-white dark:bg-gray-800 shadow rounded-md"
         style={{ width: sidebarWidth }}
       >
         <Settings settings={settings} setSettings={setSettings} />

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -485,7 +485,7 @@ export default function Calendar({
           <div
             key={dayIdx}
             ref={(el) => (dayRefs.current[dayIdx] = el)}
-            className="border p-2 relative"
+            className="bg-white rounded-md shadow p-3 relative"
             onMouseEnter={() => setHoverDay(dayIdx)}
             onMouseLeave={() => setHoverDay((h) => (h === dayIdx ? null : h))}
             onDoubleClick={(e) => {
@@ -618,7 +618,7 @@ export default function Calendar({
                             e.currentTarget.style.cursor = 'move';
                           }
                         }}
-                        className={`work-block absolute left-0 right-0 p-1 border rounded-md overflow-hidden select-none text-[10px] leading-tight ${b.taskId ? 'border-gray-300 dark:border-gray-500' : 'bg-gray-100 dark:bg-gray-600 border-gray-300 dark:border-gray-500'} ${b.taskId && b.itemId ? 'border-yellow-400' : ''} ${highlight ? 'ring-2 ring-blue-400' : ''}`}
+                        className={`work-block absolute left-0 right-0 p-1 border rounded-md overflow-hidden select-none text-[10px] leading-tight shadow-sm ${b.taskId ? 'border-gray-300 dark:border-gray-500' : 'bg-gray-100 dark:bg-gray-600 border-gray-300 dark:border-gray-500'} ${b.taskId && b.itemId ? 'border-yellow-400' : ''} ${highlight ? 'ring-2 ring-blue-400' : ''}`}
                         style={{
                           top: `${top}px`,
                           height: `${height}px`,
@@ -722,7 +722,7 @@ export default function Calendar({
                 {activeDay === dayIdx && !isDayLocked(dayIdx) && (
                   <form
                     onSubmit={addBlock}
-                    className="absolute top-0 left-0 bg-yellow-50 dark:bg-gray-800 border p-2 space-y-1 z-20"
+                    className="absolute top-0 left-0 bg-white dark:bg-gray-800 border p-2 space-y-1 z-20 shadow rounded"
                   >
                     <input
                       type="time"

--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -8,6 +8,13 @@ export default function WorkItem({ item, level = 0, notes = [], onNoteDrop }) {
     feature: 'bg-purple-100 dark:bg-purple-700',
   };
 
+  const icons = {
+    task: '✅',
+    'user story': '📝',
+    bug: '🐞',
+    feature: '📂',
+  };
+
   const colorClass = colors[item.type?.toLowerCase()] || 'bg-gray-100 dark:bg-gray-700';
   const isFeature = item.type?.toLowerCase() === 'feature';
 
@@ -40,6 +47,7 @@ export default function WorkItem({ item, level = 0, notes = [], onNoteDrop }) {
       onDragOver={allowDrop}
       onDrop={handleDrop}
     >
+      <span className="mr-1">{icons[item.type?.toLowerCase()]}</span>
       {item.title}
       {notes.length > 0 && (
         <ul className="ml-2 list-disc text-[10px]">
@@ -59,6 +67,7 @@ export default function WorkItem({ item, level = 0, notes = [], onNoteDrop }) {
       style={{ marginLeft: `${level * 1}rem` }}
     >
       <span className="font-mono mr-1">{item.id}</span>
+      <span className="mr-1">{icons[item.type?.toLowerCase()]}</span>
       {item.title}
       {notes.length > 0 && (
         <ul className="ml-4 list-disc text-[10px]">

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,7 @@ body,
   height: 100vh;
   margin: 0;
   overflow: hidden;
+  @apply font-sans;
 }
 
 .week-range {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,9 @@ module.exports = {
       width: {
         'week-range': 'var(--week-range-width)',
       },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- load Inter font from Google Fonts
- use Inter as default font family
- restyle layout spacing and side panel background
- add subtle shadows to calendar elements
- show icons for work item types

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npx jest --runInBand` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845b85d7edc832396e284c290318db6