### PR TITLE
Add lighter background for calendar blocks

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import ItemBubble from './ItemBubble';
+import { lightenColor } from '../utils/color';
 
 export default function Calendar({
   blocks,
@@ -623,7 +624,11 @@ export default function Calendar({
                           top: `${top}px`,
                           height: `${height}px`,
                           borderLeft: projectColor ? `4px solid ${projectColor}` : undefined,
-                          backgroundColor: b.taskId ? projectColor || '#e5e7eb' : undefined,
+                          backgroundColor: b.taskId
+                            ? projectColor
+                              ? lightenColor(projectColor, 70)
+                              : '#e5e7eb'
+                            : undefined,
                         }}
                       >
                         <div className="text-[10px]">

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -1,0 +1,18 @@
+export function lightenColor(color, percent = 50) {
+  if (!color) return color;
+  let c = color.replace('#', '');
+  if (c.length === 3) {
+    c = c.split('').map((ch) => ch + ch).join('');
+  }
+  const num = parseInt(c, 16);
+  const r = (num >> 16) & 0xff;
+  const g = (num >> 8) & 0xff;
+  const b = num & 0xff;
+  const p = percent / 100;
+  const nr = Math.min(255, Math.round(r + (255 - r) * p));
+  const ng = Math.min(255, Math.round(g + (255 - g) * p));
+  const nb = Math.min(255, Math.round(b + (255 - b) * p));
+  return (
+    '#' + ((1 << 24) + (nr << 16) + (ng << 8) + nb).toString(16).slice(1)
+  );
+}


### PR DESCRIPTION
## Summary
- utility to lighten hex colors
- apply lighter project color to calendar blocks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845baaf04cc83238de2fce4ece57b43