### PR TITLE
Improve text overflow handling for calendar blocks

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -678,11 +678,18 @@ export default function Calendar({
                             return task ? <ItemBubble item={task} showArea /> : null;
                           })()}
                           {!b.itemId && b.workItem && (
-                            <span className="px-1 italic">
+                            <span
+                              className="px-1 italic truncate"
+                              title={b.workItem}
+                            >
                               {b.workItem}
                             </span>
                           )}
-                          {b.note}
+                          {b.note && (
+                            <span className="truncate" title={b.note}>
+                              {b.note}
+                            </span>
+                          )}
                           {b.comments && b.comments.length > 0 && (
                             <div className="flex flex-wrap gap-1 mt-1">
                               {b.comments.map((c, idx) => (

--- a/src/components/ItemBubble.jsx
+++ b/src/components/ItemBubble.jsx
@@ -12,9 +12,13 @@ export default function ItemBubble({ item, full = false, showArea = false }) {
   const displayClass = full ? 'block w-full' : 'block';
   return (
     <div className={`${displayClass} pl-1 border-l-4 ${colorClass} text-xs`}>
-      <div className="font-medium">{item.title}</div>
+      <div className="font-medium truncate" title={item.title}>
+        {item.title}
+      </div>
       {showArea && item.area && (
-        <div className="text-[9px] mt-0.5">{item.area}</div>
+        <div className="text-[9px] mt-0.5 truncate" title={item.area}>
+          {item.area}
+        </div>
       )}
     </div>
   );

--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -46,6 +46,7 @@ export default function WorkItem({ item, level = 0, notes = [], onNoteDrop }) {
       onDragStart={dragStart}
       onDragOver={allowDrop}
       onDrop={handleDrop}
+      title={item.title}
     >
       <span className="mr-1">{icons[item.type?.toLowerCase()]}</span>
       {item.title}
@@ -65,6 +66,7 @@ export default function WorkItem({ item, level = 0, notes = [], onNoteDrop }) {
       onDrop={handleDrop}
       className={`p-1 mb-1 border ${colorClass} text-xs truncate`}
       style={{ marginLeft: `${level * 1}rem` }}
+      title={item.title}
     >
       <span className="font-mono mr-1">{item.id}</span>
       <span className="mr-1">{icons[item.type?.toLowerCase()]}</span>


### PR DESCRIPTION
## Summary
- gracefully truncate long text in ItemBubble component with ellipsis and tooltip
- add truncation and hover titles to work items and notes in calendar blocks
- show full title on hover for work item list entries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bdd00a308323abf61a5fbf83ca5d