### PR TITLE
Add week change slide animation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -202,13 +202,24 @@ function App() {
   };
 
   const [weekStart, setWeekStart] = useState(getWeekStart(new Date()));
+  const [weekAnim, setWeekAnim] = useState(null);
   const weekNumber = getWeekNumber(weekStart);
 
-  const prevWeek = () =>
+  const prevWeek = () => {
+    setWeekAnim('right');
     setWeekStart((w) => new Date(w.getTime() - 7 * 24 * 60 * 60 * 1000));
-  const nextWeek = () =>
+  };
+  const nextWeek = () => {
+    setWeekAnim('left');
     setWeekStart((w) => new Date(w.getTime() + 7 * 24 * 60 * 60 * 1000));
+  };
   const currentWeek = () => setWeekStart(getWeekStart(new Date()));
+
+  useEffect(() => {
+    if (!weekAnim) return;
+    const t = setTimeout(() => setWeekAnim(null), 200);
+    return () => clearTimeout(t);
+  }, [weekAnim]);
 
   const formatRange = () => {
     const end = new Date(weekStart);
@@ -368,6 +379,7 @@ function App() {
           onCommentDrop={handleBlockCommentDrop}
           lockedDays={lockedDays}
           setLockedDays={setLockedDays}
+          animDirection={weekAnim}
         />
         <Notes notes={notes} onAdd={addNote} onDelete={deleteNote} />
       </div>

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -15,6 +15,7 @@ export default function Calendar({
   onCommentDrop,
   lockedDays = {},
   setLockedDays,
+  animDirection = null,
 }) {
   const weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
   const days = settings.workDays;
@@ -479,9 +480,20 @@ export default function Calendar({
     }
   };
 
+  const animClass =
+    animDirection === 'left'
+      ? 'week-slide-left'
+      : animDirection === 'right'
+      ? 'week-slide-right'
+      : '';
+
   return (
-    <div>
-      <div className="grid gap-2" style={{ gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))` }}>
+    <div className="overflow-hidden">
+      <div
+        key={weekStart.toISOString()}
+        className={`grid gap-2 ${animClass}`}
+        style={{ gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))` }}
+      >
         {days.map((dayIdx, idx) => (
           <div
             key={dayIdx}

--- a/src/index.css
+++ b/src/index.css
@@ -81,3 +81,29 @@ body,
   cursor: col-resize;
   @apply bg-gray-300 dark:bg-gray-700;
 }
+
+@keyframes slideLeft {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideRight {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+.week-slide-left {
+  animation: slideLeft 0.2s ease-out;
+}
+
+.week-slide-right {
+  animation: slideRight 0.2s ease-out;
+}


### PR DESCRIPTION
## Summary
- animate the calendar when moving between weeks
- slide new week in from the left or right
- add CSS keyframes for sliding transitions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bf0b15e48323899f88a68df6c3d0