### PR TITLE
Improve locked day visibility

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -513,7 +513,9 @@ export default function Calendar({
             }}
           >
             {isDayLocked(dayIdx) && (
-              <div className="absolute inset-0 bg-gray-500 dark:bg-gray-600 opacity-10 pointer-events-none z-20" />
+              <div className="absolute inset-0 bg-gray-500/50 dark:bg-gray-600/50 flex items-center justify-center pointer-events-none z-20">
+                <span className="text-4xl text-gray-700 dark:text-gray-300">🔒</span>
+              </div>
             )}
             {hoverDay === dayIdx && (
               <button


### PR DESCRIPTION
## Summary
- show a translucent overlay and lock icon when day is locked

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c604f2d083239ada9714e6beef2c