### PR TITLE
Handle closed day data and fetch all items

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,23 +59,10 @@ function App() {
   };
 
   const fetchWorkItems = useCallback(() => {
-    const {
-      azureOrg,
-      azurePat,
-      azureProjects,
-      azureTags,
-      azureArea,
-      azureIteration,
-    } = settings;
+    const { azureOrg, azurePat } = settings;
     if (!azureOrg || !azurePat) return;
-    const service = new AdoService(
-      azureOrg,
-      azurePat,
-      azureProjects,
-      azureTags,
-      azureArea,
-      azureIteration
-    );
+    // Fetch all work items without applying stored filters.
+    const service = new AdoService(azureOrg, azurePat);
     service.getWorkItems().then((data) => {
       setItems((prev) => {
         const map = new Map(data.map((i) => [i.id, i]));
@@ -93,16 +80,7 @@ function App() {
       });
       setItemsFetched(true);
     });
-  }, [
-    settings.azureOrg,
-    settings.azurePat,
-    settings.azureProjects,
-    settings.azureTags,
-    settings.azureArea,
-    settings.azureIteration,
-    setItems,
-    blocks,
-  ]);
+  }, [settings.azureOrg, settings.azurePat, setItems, blocks]);
 
   useEffect(() => {
     if (settings.darkMode) {

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -102,15 +102,26 @@ export default function Calendar({
     return d.toISOString().split('T')[0];
   };
 
-  const isDayLocked = (idx) => lockedDays[dayKey(idx)];
+  const isDayLocked = (idx) => !!lockedDays[dayKey(idx)];
 
   const toggleDayLock = (idx) => {
     if (!setLockedDays) return;
     const key = dayKey(idx);
     setLockedDays((prev) => {
       const next = { ...prev };
-      if (next[key]) delete next[key];
-      else next[key] = true;
+      if (next[key]) {
+        delete next[key];
+      } else {
+        const dayStart = new Date(weekStart);
+        dayStart.setDate(weekStart.getDate() + idx);
+        const dayEnd = new Date(dayStart);
+        dayEnd.setDate(dayStart.getDate() + 1);
+        const dayBlocks = blocks.filter((b) => {
+          const bs = new Date(b.start);
+          return bs >= dayStart && bs < dayEnd;
+        });
+        next[key] = { closed: true, blocks: dayBlocks };
+      }
       return next;
     });
   };

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -39,7 +39,18 @@ export default function useSettings() {
     const patService = new PatService();
     Promise.resolve(patService.get()).then((pat) => {
       if (data) {
-        setSettings({ ...defaultSettings, ...data, azurePat: pat });
+        const {
+          azureProjects,
+          azureTags,
+          azureArea,
+          azureIteration,
+          ...rest
+        } = data;
+        setSettings({
+          ...defaultSettings,
+          ...rest,
+          azurePat: pat,
+        });
       } else {
         setSettings({ ...defaultSettings, azurePat: pat });
       }
@@ -50,7 +61,14 @@ export default function useSettings() {
   useEffect(() => {
     if (!loaded) return;
     const storage = new StorageService('settings');
-    const { azurePat, ...persist } = settings;
+    const {
+      azurePat,
+      azureProjects,
+      azureTags,
+      azureArea,
+      azureIteration,
+      ...persist
+    } = settings;
     storage.write(persist);
     const patService = new PatService();
     patService.set(azurePat);


### PR DESCRIPTION
## Summary
- avoid persisting work item filter fields
- fetch all work items on login without applying filters
- save a snapshot of blocks when locking a day

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c6c40868832388a27e9f577084e8