### PR TITLE
Ignore right click when dragging blocks

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -265,6 +265,7 @@ export default function Calendar({
   };
 
   const startBlockDrag = (e, block, dayIdx) => {
+    if (e.button !== 0) return; // only start on left click
     if (
       e.target.closest('button') ||
       e.target.closest('input') ||


### PR DESCRIPTION
## Summary
- prevent block drag from starting on right click so the context menu can open

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845cd42a3648323a7e6a8ade13ae758