### PR TITLE
Fix context menu right click

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -77,10 +77,8 @@ export default function Calendar({
     if (!contextMenu) return;
     const close = () => setContextMenu(null);
     window.addEventListener('click', close);
-    window.addEventListener('contextmenu', close);
     return () => {
       window.removeEventListener('click', close);
-      window.removeEventListener('contextmenu', close);
     };
   }, [contextMenu]);
 
@@ -646,6 +644,7 @@ export default function Calendar({
                         }}
                         onContextMenu={(e) => {
                           e.preventDefault();
+                          e.stopPropagation();
                           if (isDayLocked(dayIdx)) return;
                           setContextMenu({ id: b.id, x: e.clientX, y: e.clientY });
                         }}


### PR DESCRIPTION
## Summary
- fix context menu staying closed because of global listener
- stop event propagation when opening the right-click menu

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ce43b9f88323b61528a092966c23