### PR TITLE
Add Patrak branding and animated logo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-Calendar-Ado Proprietary License
+Patrak Proprietary License
 
-Copyright (c) 2023 The Calendar-Ado Authors. All rights reserved.
+Copyright (c) 2023 The Patrak Authors. All rights reserved.
 
 Unauthorized copying, modification, distribution, or use of this software is
 strictly prohibited. Permission to use this software must be obtained in writing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Calendar-Ado
+# Patrak
 **Blueprint: ADO Calendar-Based Work Logger**
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "calendar-ado",
+  "name": "patrak",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "calendar-ado",
+      "name": "patrak",
       "version": "0.1.0",
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "calendar-ado",
+  "name": "patrak",
   "version": "0.1.0",
   "private": true,
   "homepage": "./",

--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,12 @@
     href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
     rel="stylesheet"
   />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&display=swap"
+    rel="stylesheet"
+  />
   <link rel="icon" href="%PUBLIC_URL%/icon.png" />
-  <title>Calendar ADO</title>
+  <title>Patrak</title>
 </head>
 <body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
   <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import WorkItems from './components/WorkItems';
 import Settings from './components/Settings';
 import YearHint from './components/YearHint';
 import Notes from './components/Notes';
+import PatrakLogo from './components/PatrakLogo';
 import useWorkBlocks from './hooks/useWorkBlocks';
 import useSettings from './hooks/useSettings';
 import useAdoItems from './hooks/useAdoItems';
@@ -348,7 +349,7 @@ function App() {
             No time logged today. Don't forget to log your work!
           </div>
         )}
-        <h1 className="text-2xl font-bold mb-4">Calendar-Ado</h1>
+        <PatrakLogo />
         <div className="mb-2 flex items-center space-x-2">
           <button className="week-nav-button" onClick={prevWeek}>
             ◀ Prev

--- a/src/components/PatrakLogo.jsx
+++ b/src/components/PatrakLogo.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+
+export default function PatrakLogo({ className = '' }) {
+  const [flipping, setFlipping] = useState(false);
+
+  useEffect(() => {
+    let flipTimeout;
+    let scheduleTimeout;
+
+    const schedule = () => {
+      scheduleTimeout = setTimeout(() => {
+        setFlipping(true);
+        flipTimeout = setTimeout(() => {
+          setFlipping(false);
+          schedule();
+        }, 2300);
+      }, 15000);
+    };
+
+    schedule();
+    return () => {
+      clearTimeout(flipTimeout);
+      clearTimeout(scheduleTimeout);
+    };
+  }, []);
+
+  return (
+    <h1 className={`text-2xl font-bold mb-4 font-oswald ${className}`}>
+      <span className="logo-letter">P</span>
+      <span className="logo-letter">A</span>
+      <span className="logo-letter">T</span>
+      <span className="logo-letter">R</span>
+      <span className={`logo-letter ${flipping ? 'flip-a' : ''}`}>A</span>
+      <span className="logo-letter">K</span>
+    </h1>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -107,3 +107,27 @@ body,
 .week-slide-right {
   animation: slideRight 0.2s ease-out;
 }
+
+.logo-letter {
+  display: inline-block;
+}
+
+@keyframes flipA {
+  0%, 100% {
+    transform: rotateX(0deg);
+    color: inherit;
+  }
+  40% {
+    transform: rotateX(-140deg);
+    color: #3b82f6;
+  }
+  60% {
+    transform: rotateX(-60deg);
+    color: #3b82f6;
+  }
+}
+
+.flip-a {
+  animation: flipA 2.3s ease-in-out;
+  transform-origin: center;
+}

--- a/src/services/patService.js
+++ b/src/services/patService.js
@@ -22,7 +22,7 @@ try {
 }
 
 export default class PatService {
-  constructor(service = 'calendar-ado', account = 'azure-pat') {
+  constructor(service = 'patrak', account = 'azure-pat') {
     this.service = service;
     this.account = account;
   }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
       },
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        oswald: ['Oswald', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- rebrand app to **Patrak**
- add Oswald font and animated Patrak logo component
- replace Calendar-Ado references
- adjust keytar service name

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471fde2b5c8323aaf66154d094092e