### PR TITLE
Allow direct logging for bug and transversal items

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## 1. Overview
 
-A productivity tool to help software engineers and technical professionals track work in real-time, using a calendar-based interface. It integrates with Azure DevOps (ADO) and allows users to log time against tasks efficiently, even when tasks aren't yet created.
+A productivity tool to help software engineers and technical professionals track work in real-time, using a calendar-based interface. It integrates with Azure DevOps (ADO) and allows users to log time against tasks, bugs, and transversal activities efficiently, even when tasks aren't yet created.
 
 This tool aims to reduce friction in time logging, ensure compliance with area path and job order constraints, and streamline weekly reporting.
 
@@ -60,7 +60,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 
 * Personal Access Token (PAT) authentication
 * Read work items and area paths
-* Write time logs to tasks (PATCH work item updates with time + comment)
+* Write time logs to tasks, bugs, and transversal activities (PATCH work item updates with time + comment)
 * Read-only enforcement on already-submitted blocks
 
 ### 3.5 Sync & Review

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -452,13 +452,21 @@ export default function Calendar({
     if (!raw) return;
     const item = JSON.parse(raw);
     if (!item) return;
-    if (item.type?.toLowerCase() === 'task') {
+    const type = item.type?.toLowerCase();
+    if (type === 'task') {
       const display = findDisplayItem(item);
       if (onUpdate)
         onUpdate(blockId, {
           workItem: display.title,
           taskId: item.id,
           itemId: display.id,
+        });
+    } else if (type === 'bug' || type === 'transversal activity') {
+      if (onUpdate)
+        onUpdate(blockId, {
+          workItem: item.title,
+          taskId: item.id,
+          itemId: item.id,
         });
     } else {
       const tasks = getDescendantTasks(item.id);

--- a/src/components/ItemBubble.jsx
+++ b/src/components/ItemBubble.jsx
@@ -7,6 +7,7 @@ export default function ItemBubble({ item, full = false, showArea = false }) {
     'user story': 'border-blue-400',
     bug: 'border-red-400',
     feature: 'border-purple-400',
+    'transversal activity': 'border-green-400',
   };
   const colorClass = colors[item.type?.toLowerCase()] || 'border-gray-400';
   const displayClass = full ? 'block w-full' : 'block';

--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -6,6 +6,7 @@ export default function WorkItem({ item, level = 0, notes = [], onNoteDrop }) {
     'user story': 'bg-blue-100 dark:bg-blue-700',
     bug: 'bg-red-100 dark:bg-red-700',
     feature: 'bg-purple-100 dark:bg-purple-700',
+    'transversal activity': 'bg-green-100 dark:bg-green-700',
   };
 
   const icons = {
@@ -13,6 +14,7 @@ export default function WorkItem({ item, level = 0, notes = [], onNoteDrop }) {
     'user story': '📝',
     bug: '🐞',
     feature: '📂',
+    'transversal activity': '🔧',
   };
 
   const colorClass = colors[item.type?.toLowerCase()] || 'bg-gray-100 dark:bg-gray-700';


### PR DESCRIPTION
## Summary
- allow dropping Bug or Transversal Activity items directly onto calendar blocks
- color & icon support for Transversal Activity items
- update item bubble colors
- clarify README usage notes around logging to Bugs and Transversal Activities

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684848d1f3888323b913b63b4f476529