### PR TITLE
Add transversal activity support

### DIFF
--- a/src/components/ItemBubble.jsx
+++ b/src/components/ItemBubble.jsx
@@ -9,11 +9,20 @@ export default function ItemBubble({ item, full = false, showArea = false }) {
     feature: 'border-purple-400',
     'transversal activity': 'border-green-400',
   };
+  const icons = {
+    task: '🛠',
+    'user story': '📝',
+    bug: '🐞',
+    feature: '📂',
+    // icon for transversal activities
+    'transversal activity': '🔧',
+  };
   const colorClass = colors[item.type?.toLowerCase()] || 'border-gray-400';
   const displayClass = full ? 'block w-full' : 'block';
   return (
     <div className={`${displayClass} pl-1 border-l-4 ${colorClass} text-xs`}>
       <div className="font-medium truncate" title={item.title}>
+        <span className="mr-1">{icons[item.type?.toLowerCase()]}</span>
         {item.title}
       </div>
       {showArea && item.area && (

--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -6,6 +6,7 @@ export default function WorkItem({ item, level = 0, notes = [], onNoteDrop }) {
     'user story': 'bg-blue-100 dark:bg-blue-700',
     bug: 'bg-red-100 dark:bg-red-700',
     feature: 'bg-purple-100 dark:bg-purple-700',
+    // color for transversal activities
     'transversal activity': 'bg-green-100 dark:bg-green-700',
   };
 
@@ -14,6 +15,7 @@ export default function WorkItem({ item, level = 0, notes = [], onNoteDrop }) {
     'user story': '📝',
     bug: '🐞',
     feature: '📂',
+    // icon for transversal activities
     'transversal activity': '🔧',
   };
 

--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -274,6 +274,7 @@ export default function WorkItems({
             <option value="user story">User Stories</option>
             <option value="bug">Bugs</option>
             <option value="task">Tasks</option>
+            <option value="transversal activity">Transversal Activity</option>
           </select>
         </div>
         <div className="mb-2 relative" ref={groupRefs.tags}>


### PR DESCRIPTION
## Summary
- show icons in ItemBubble
- document color & icons for transversal activities
- expose Transversal Activity in work item type filter

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484d530b948323a91eb988c3ed5a0b