### PR TITLE
Add locked day curtain with area summary

### DIFF
--- a/__tests__/summary.test.js
+++ b/__tests__/summary.test.js
@@ -1,0 +1,26 @@
+const { summarizeByArea } = require('../src/utils/summary');
+
+test('groups hours by area', () => {
+  const blocks = [
+    { start: '2023-01-01T09:00:00.000Z', end: '2023-01-01T10:00:00.000Z', taskId: '1' },
+    { start: '2023-01-01T11:00:00.000Z', end: '2023-01-01T12:30:00.000Z', taskId: '2' },
+  ];
+  const items = [
+    { id: '1', area: 'AAA' },
+    { id: '2', area: 'BBB' },
+  ];
+  const date = new Date('2023-01-01T00:00:00.000Z');
+  const summary = summarizeByArea(blocks, items, date);
+  expect(summary.AAA).toBeCloseTo(1);
+  expect(summary.BBB).toBeCloseTo(1.5);
+});
+
+test('handles missing item', () => {
+  const blocks = [
+    { start: '2023-01-01T09:00:00.000Z', end: '2023-01-01T10:00:00.000Z', taskId: '1' },
+  ];
+  const items = [];
+  const date = new Date('2023-01-01T00:00:00.000Z');
+  const summary = summarizeByArea(blocks, items, date);
+  expect(summary.Unassigned).toBeCloseTo(1);
+});

--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import ItemBubble from './ItemBubble';
 import { lightenColor } from '../utils/color';
+import { summarizeByArea } from '../utils/summary';
 
 export default function Calendar({
   blocks,
@@ -112,6 +113,12 @@ export default function Calendar({
   };
 
   const isDayLocked = (idx) => lockedDays[dayKey(idx)];
+
+  const areaSummaryForDay = (idx) => {
+    const date = new Date(weekStart);
+    date.setDate(weekStart.getDate() + idx);
+    return summarizeByArea(blocks, items, date);
+  };
 
   const toggleDayLock = (idx) => {
     if (!setLockedDays) return;
@@ -531,8 +538,16 @@ export default function Calendar({
             }}
           >
             {isDayLocked(dayIdx) && (
-              <div className="absolute inset-0 bg-gray-500/50 dark:bg-gray-600/50 flex items-center justify-center pointer-events-none z-20">
+              <div className="absolute inset-0 bg-gray-500/50 dark:bg-gray-600/50 pointer-events-none z-20 curtain-slide-down flex flex-col items-center pt-2">
                 <span className="text-4xl text-gray-700 dark:text-gray-300">🔒</span>
+                <div className="mt-2 bg-white/80 dark:bg-gray-700/80 text-[10px] rounded px-2 py-1">
+                  {Object.entries(areaSummaryForDay(dayIdx)).map(([area, hrs]) => (
+                    <div key={area} className="flex justify-between gap-2 whitespace-nowrap">
+                      <span>{area}</span>
+                      <span>{hrs.toFixed(1)}h</span>
+                    </div>
+                  ))}
+                </div>
               </div>
             )}
             {hoverDay === dayIdx && (

--- a/src/index.css
+++ b/src/index.css
@@ -108,6 +108,19 @@ body,
   animation: slideRight 0.2s ease-out;
 }
 
+@keyframes slideDown {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.curtain-slide-down {
+  animation: slideDown 0.3s ease-out;
+}
+
 .logo-letter {
   display: inline-block;
 }

--- a/src/utils/summary.js
+++ b/src/utils/summary.js
@@ -1,0 +1,15 @@
+export function summarizeByArea(blocks, items, dayDate) {
+  const dateStr = dayDate.toDateString();
+  const summary = {};
+  for (const b of blocks) {
+    const start = new Date(b.start);
+    if (start.toDateString() !== dateStr) continue;
+    const end = new Date(b.end);
+    const hrs = (end - start) / (1000 * 60 * 60);
+    const itemId = b.itemId || b.taskId;
+    const item = items?.find((i) => i.id === itemId);
+    const area = item?.area || 'Unassigned';
+    summary[area] = (summary[area] || 0) + hrs;
+  }
+  return summary;
+}


### PR DESCRIPTION
## Summary
- slide down effect for locked days
- compute summary of hours by area
- show new locked day curtain with summary
- test summarizeByArea utility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d10c256c83239ba51e25345a8f55