### PR TITLE
Simplify work items list view

### DIFF
--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -6,6 +6,7 @@ export default function WorkItem({
   notes = [],
   onNoteDrop,
   highlight = false,
+  pill = false,
 }) {
   const colors = {
     task: 'bg-yellow-100 dark:bg-yellow-700',
@@ -27,6 +28,7 @@ export default function WorkItem({
 
   const colorClass = colors[item.type?.toLowerCase()] || 'bg-gray-100 dark:bg-gray-700';
   const isFeature = item.type?.toLowerCase() === 'feature';
+  const isTask = item.type?.toLowerCase() === 'task';
 
   const dragStart = (e) => {
     e.dataTransfer.setData(
@@ -50,15 +52,17 @@ export default function WorkItem({
   };
 
   const highlightClass = highlight ? 'ring-2 ring-red-500' : '';
+  const asPill = isFeature || pill;
 
-  return isFeature ? (
+  return asPill ? (
     <div
-      className={`inline-block rounded-full px-2 py-1 bg-purple-200 dark:bg-purple-700 text-xs font-semibold mr-2 mb-2 ${highlightClass}`}
+      className={`inline-block rounded-full px-2 py-1 ${colorClass} text-xs font-semibold mr-2 mb-2 ${highlightClass}`}
       draggable
       onDragStart={dragStart}
       onDragOver={allowDrop}
       onDrop={handleDrop}
       title={item.title}
+      style={{ marginLeft: `${level * 0.5}rem` }}
     >
       <span className="mr-1">{icons[item.type?.toLowerCase()]}</span>
       {item.title}


### PR DESCRIPTION
## Summary
- show tasks as compact pills under their parent
- organize work items by project only with collapsable features

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d1e0aec0832396abac2d21d9d56e