### PR TITLE
Fix block splitting across lunch and overlaps

### DIFF
--- a/__tests__/timeAdjust.test.js
+++ b/__tests__/timeAdjust.test.js
@@ -2,6 +2,7 @@ const {
   trimLunchOverlap,
   adjustForOverlap,
   splitByLunch,
+  splitForOverlaps,
 } = require('../src/utils/timeAdjust');
 
 describe('trimLunchOverlap', () => {
@@ -70,5 +71,25 @@ describe('splitByLunch', () => {
     expect(result).toHaveLength(2);
     expect(result[0].end).toBe('2023-01-01T12:00:00.000Z');
     expect(result[1].start).toBe('2023-01-01T13:00:00.000Z');
+  });
+});
+
+describe('splitForOverlaps', () => {
+  const existing = [
+    { start: '2023-01-01T10:00:00.000Z', end: '2023-01-01T11:00:00.000Z' },
+  ];
+
+  test('splits around existing block', () => {
+    const block = { start: '2023-01-01T09:00:00.000Z', end: '2023-01-01T12:00:00.000Z' };
+    const result = splitForOverlaps(existing, block);
+    expect(result).toHaveLength(2);
+    expect(result[0].end).toBe('2023-01-01T10:00:00.000Z');
+    expect(result[1].start).toBe('2023-01-01T11:00:00.000Z');
+  });
+
+  test('returns empty when inside existing block', () => {
+    const block = { start: '2023-01-01T10:15:00.000Z', end: '2023-01-01T10:45:00.000Z' };
+    const result = splitForOverlaps(existing, block);
+    expect(result).toHaveLength(0);
   });
 });

--- a/src/utils/timeAdjust.js
+++ b/src/utils/timeAdjust.js
@@ -93,3 +93,38 @@ export function adjustForOverlap(blocks, newBlock) {
   return { ...newBlock, start: start.toISOString(), end: end.toISOString() };
 }
 
+export function splitForOverlaps(blocks, newBlock) {
+  let segments = [newBlock];
+  const sorted = [...blocks].sort(
+    (a, b) => new Date(a.start) - new Date(b.start)
+  );
+  for (const b of sorted) {
+    const bStart = new Date(b.start);
+    const bEnd = new Date(b.end);
+    const newSegments = [];
+    for (const seg of segments) {
+      let start = new Date(seg.start);
+      let end = new Date(seg.end);
+      if (end <= bStart || start >= bEnd) {
+        newSegments.push(seg);
+        continue;
+      }
+      if (start < bStart) {
+        if (end > bEnd) {
+          newSegments.push({ ...seg, end: bStart.toISOString() });
+          newSegments.push({ ...seg, start: bEnd.toISOString() });
+        } else {
+          newSegments.push({ ...seg, end: bStart.toISOString() });
+        }
+      } else if (start >= bStart && start < bEnd) {
+        if (end > bEnd) {
+          newSegments.push({ ...seg, start: bEnd.toISOString() });
+        }
+      }
+    }
+    segments = newSegments;
+    if (!segments.length) break;
+  }
+  return segments;
+}
+


### PR DESCRIPTION
## Summary
- add `splitForOverlaps` helper to break up a block around existing blocks
- create calendar blocks using this new helper
- update tests for new function

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d2ac05788323972fd192a0d33a6a