### PR TITLE
Improve DevOps review

### DIFF
--- a/__tests__/treeProblems.test.js
+++ b/__tests__/treeProblems.test.js
@@ -1,0 +1,26 @@
+const AdoService = require('../src/services/adoService.js').default;
+
+test('detects invalid hierarchy', () => {
+  const svc = new AdoService();
+  const items = [
+    { id: '1', title: 'Epic', type: 'Epic' },
+    { id: '2', title: 'Feature no parent', type: 'Feature' },
+    { id: '3', title: 'Feature ok', type: 'Feature', parentId: '1' },
+    { id: '4', title: 'Story wrong parent', type: 'User Story', parentId: '2' },
+    { id: '5', title: 'Story ok', type: 'User Story', parentId: '3' },
+    { id: '6', title: 'Task bad parent', type: 'Task', parentId: '3' },
+    { id: '7', title: 'Task ok', type: 'Task', parentId: '5' },
+    { id: '8', title: 'Bug wrong parent', type: 'Bug', parentId: '5' },
+    { id: '9', title: 'Bug ok', type: 'Bug', parentId: '3' },
+    { id: '10', title: 'Transversal bad', type: 'Transversal Activity', parentId: '5' },
+    { id: '11', title: 'Transversal ok', type: 'Transversal Activity', parentId: '3' },
+  ];
+  const problems = svc.findTreeProblems(items);
+  const ids = problems.map(p => p.id);
+  expect(ids).toEqual(expect.arrayContaining(['2', '4', '6', '8', '10']));
+  expect(ids).not.toContain('3');
+  expect(ids).not.toContain('5');
+  expect(ids).not.toContain('7');
+  expect(ids).not.toContain('9');
+  expect(ids).not.toContain('11');
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,7 @@ import useSettings from './hooks/useSettings';
 import useAdoItems from './hooks/useAdoItems';
 import useNotes from './hooks/useNotes';
 import useDayLocks from './hooks/useDayLocks';
-import AdoService from './services/adoService';
+import AdoService from './services/adoService.js';
 import {
   trimLunchOverlap,
   hasOverlap,
@@ -350,14 +350,11 @@ function App() {
   );
   const missingArea = reviewService.findMissingArea(items);
   const missingIteration = reviewService.findMissingIteration(items);
-  const invalidState = reviewService.findIncorrectState(
-    items,
-    settings.stateOrder
-  );
+  const treeProblems = reviewService.findTreeProblems(items);
   const highlightedIds = new Set([
     ...missingArea.map((i) => i.id),
     ...missingIteration.map((i) => i.id),
-    ...invalidState.map((i) => i.id),
+    ...treeProblems.map((i) => i.id),
   ]);
 
   return (

--- a/src/components/DevOpsReview.jsx
+++ b/src/components/DevOpsReview.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AdoService from '../services/adoService';
+import AdoService from '../services/adoService.js';
 
 export default function DevOpsReview({ items = [], settings }) {
   const service = new AdoService(
@@ -13,7 +13,7 @@ export default function DevOpsReview({ items = [], settings }) {
 
   const missingArea = service.findMissingArea(items);
   const missingIteration = service.findMissingIteration(items);
-  const invalidState = service.findIncorrectState(items, settings.stateOrder);
+  const treeProblems = service.findTreeProblems(items);
 
   const renderList = (list) => (
     <ul className="ml-4 list-disc text-xs mt-1">
@@ -44,9 +44,9 @@ export default function DevOpsReview({ items = [], settings }) {
         </div>
         <div>
           <div className="font-semibold text-sm">
-            Incorrect State ({invalidState.length})
+            DevOps Tree Problems ({treeProblems.length})
           </div>
-          {invalidState.length > 0 && renderList(invalidState)}
+          {treeProblems.length > 0 && renderList(treeProblems)}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove incorrect state check from DevOps review
- highlight hierarchy problems instead
- add `findTreeProblems` to detect invalid DevOps item parents
- update highlight logic in app
- test tree problem detection

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d4bbb5a08323a78ae7200629c2c6