### PR TITLE
Improve hierarchy for work item list

### DIFF
--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -52,11 +52,11 @@ export default function WorkItem({
   };
 
   const highlightClass = highlight ? 'ring-2 ring-red-500' : '';
-  const asPill = isFeature || pill;
+  const asPill = pill;
 
   return asPill ? (
     <div
-      className={`inline-block rounded-full px-2 py-1 ${colorClass} text-xs font-semibold mr-2 mb-2 ${highlightClass}`}
+      className={`inline-block task-pill px-2 py-1 ${colorClass} text-xs font-semibold mr-2 mb-2 ${highlightClass}`}
       draggable
       onDragStart={dragStart}
       onDragOver={allowDrop}

--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -29,7 +29,7 @@ function renderTree(
   return nodes.map((node) => {
     const isFeature = node.type?.toLowerCase() === 'feature';
     const collapsed = featureCollapsed[node.id];
-    const containerClass = isFeature ? 'block' : 'inline-block';
+    const containerClass = isFeature ? 'block w-full' : 'inline-block';
     return (
       <div key={node.id} className={containerClass}>
         <div className={isFeature ? 'flex items-center cursor-pointer' : ''} onClick={() => isFeature && toggleFeature(node.id)}>
@@ -41,7 +41,7 @@ function renderTree(
             highlight={highlightIds?.has(node.id)}
             pill={node.type?.toLowerCase() === 'task' && level > 0}
           />
-          {isFeature && (
+          {isFeature && node.children.length > 0 && (
             <span className="ml-1 text-xs">{collapsed ? '▶' : '▼'}</span>
           )}
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -147,3 +147,6 @@ body,
   animation: rotateA 2s ease-in-out;
   transform-origin: top center;
 }
+
+.task-pill { @apply rounded-b-full rounded-t-md; }
+


### PR DESCRIPTION
## Summary
- tweak WorkItem pill logic and style
- expand WorkItem tree rows to full width for features and hide expand icon for empty features
- add `.task-pill` style

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d55c7e908323834b6fe49030b44e