### PR TITLE
Improve locked day curtain visuals

### DIFF
--- a/src/components/Calendar.jsx
+++ b/src/components/Calendar.jsx
@@ -837,21 +837,21 @@ export default function Calendar({
         ))}
       </div>
       <div
-        className="pointer-events-none absolute inset-0 grid gap-2 z-20"
+        className="pointer-events-auto absolute inset-0 grid gap-2 z-20"
         style={{ gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))` }}
       >
         {groups.map((g, i) => (
           <div
             key={i}
-            className="bg-gray-500 dark:bg-gray-600 curtain-slide-down flex flex-col items-center pt-2 rounded"
+            className="bg-gray-500/40 dark:bg-gray-600/40 curtain-slide-down flex flex-col items-center pt-2 rounded"
             style={{ gridColumn: `${g.start + 1} / ${g.end + 2}` }}
           >
             <span className="text-4xl text-gray-700 dark:text-gray-300">🔒</span>
-            <div className="mt-2 bg-white/80 dark:bg-gray-700/80 text-xs rounded px-2 py-1 pointer-events-auto w-full overflow-hidden">
+            <div className="mt-2 bg-white/80 dark:bg-gray-700/80 text-xs rounded px-2 py-1 pointer-events-auto w-full overflow-hidden divide-y divide-gray-300 dark:divide-gray-600">
               {Object.entries(g.summary).map(([area, hrs]) => (
                 <div
                   key={area}
-                  className="flex justify-between gap-2 whitespace-nowrap w-full cursor-pointer"
+                  className="flex justify-between gap-2 whitespace-nowrap w-full cursor-pointer py-0.5"
                   onContextMenu={(e) => {
                     e.preventDefault();
                     if (!setAreaAliases) return;


### PR DESCRIPTION
## Summary
- lighten locked day overlay so underlying components remain visible
- allow right-clicking in area summary within the curtain
- add divider between areas for better separation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dbc3215c83239e5fb14b7643fe0d