### PR TITLE
Cache work items locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 
 * Personal Access Token (PAT) authentication
 * Read work items and area paths
+* Work items are cached locally; refresh only fetches updates since the last sync
 * Write time logs to tasks, bugs, and transversal activities (PATCH work item updates with time + comment)
 * Read-only enforcement on already-submitted blocks
 
@@ -237,6 +238,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 
    * `storageService.js`: read/write JSON or SQLite
    * Store: `workBlocks`, `workItemCache`
+   * Cache tracks the last fetch time so only updated work items are requested
 
 4. **Calendar UI**
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,7 +24,7 @@ import { getWeekNumber } from './utils/date';
 function App() {
   const { blocks, setBlocks } = useWorkBlocks();
   const { settings, setSettings } = useSettings();
-  const { items, setItems } = useAdoItems();
+  const { items, setItems, lastFetch, setLastFetch } = useAdoItems();
   const { notes, setNotes, itemNotes, setItemNotes } = useNotes();
   const { lockedDays, setLockedDays } = useDayLocks();
   const { aliases: areaAliases, setAliases: setAreaAliases } = useAreaAliases();
@@ -80,7 +80,8 @@ function App() {
       azureArea,
       azureIteration
     );
-    service.getWorkItems().then((data) => {
+    const since = lastFetch ? new Date(lastFetch) : null;
+    service.getWorkItems(since).then((data) => {
       setItems((prev) => {
         const map = new Map(data.map((i) => [i.id, i]));
         const blockIds = new Set();
@@ -96,6 +97,7 @@ function App() {
         return Array.from(map.values());
       });
       setItemsFetched(true);
+      setLastFetch(Date.now());
     });
   }, [
     settings.azureOrg,
@@ -106,6 +108,7 @@ function App() {
     settings.azureIteration,
     setItems,
     blocks,
+    lastFetch,
   ]);
 
   useEffect(() => {

--- a/src/hooks/useAdoItems.js
+++ b/src/hooks/useAdoItems.js
@@ -1,10 +1,29 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import StorageService from '../services/storageService';
 
 export default function useAdoItems() {
   const [items, setItems] = useState([]);
+  const [lastFetch, setLastFetch] = useState(0);
+
+  useEffect(() => {
+    const storage = new StorageService('workItemCache', {
+      items: [],
+      lastFetch: 0,
+    });
+    const data = storage.read();
+    setItems(data.items || []);
+    setLastFetch(data.lastFetch || 0);
+  }, []);
+
+  useEffect(() => {
+    const storage = new StorageService('workItemCache');
+    storage.write({ items, lastFetch });
+  }, [items, lastFetch]);
 
   return {
     items,
     setItems,
+    lastFetch,
+    setLastFetch,
   };
 }

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -21,7 +21,7 @@ export default class AdoService {
         : (str) => Buffer.from(str).toString('base64');
   }
 
-  _buildQuery() {
+  _buildQuery(since = null) {
     const projectFilter = this.projects.length
       ? `[System.TeamProject] in (${this.projects
           .map((p) => `'${p}'`)
@@ -36,13 +36,16 @@ export default class AdoService {
     const iterationFilter = this.iteration
       ? `[System.IterationPath] under '${this.iteration}' and `
       : '';
+    const dateFilter = since
+      ? `[System.ChangedDate] >= '${since.toISOString()}'`
+      : '[System.ChangedDate] >= @Today - 30';
     return (
       'Select [System.Id] From WorkItems Where ' +
       projectFilter +
       tagFilter +
       areaFilter +
       iterationFilter +
-      '[System.ChangedDate] >= @Today - 30 order by [System.ChangedDate] desc'
+      `${dateFilter} order by [System.ChangedDate] desc`
     );
   }
 
@@ -79,7 +82,7 @@ export default class AdoService {
     );
   }
 
-  async getWorkItems() {
+  async getWorkItems(since = null) {
     if (!this.org || !this.token) {
       return [];
     }
@@ -95,7 +98,7 @@ export default class AdoService {
             Authorization: auth,
           },
           body: JSON.stringify({
-            query: this._buildQuery(),
+            query: this._buildQuery(since),
           }),
         }
       );


### PR DESCRIPTION
## Summary
- store fetched work items locally
- track last refresh time in work item cache
- only query Azure DevOps for items updated since last refresh
- document caching behavior

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dd3c44b083238d98fedfcc3f896e