### PR TITLE
Add area alias tab in notes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import Calendar from './components/Calendar';
 import HoursSummary from './components/HoursSummary';
 import WorkItems from './components/WorkItems';
@@ -36,6 +36,17 @@ function App() {
   const [resizing, setResizing] = useState(false);
   const [showReminder, setShowReminder] = useState(false);
   const [panelTab, setPanelTab] = useState('workItems');
+
+  const usedAreas = useMemo(() => {
+    const set = new Set();
+    const itemMap = Object.fromEntries(items.map((i) => [i.id, i]));
+    for (const b of blocks) {
+      const item = itemMap[b.itemId || b.taskId];
+      const area = item?.area || 'Unassigned';
+      if (area) set.add(area);
+    }
+    return Array.from(set).sort();
+  }, [blocks, items]);
 
   const addNote = (text) =>
     setNotes((prev) => [...prev, { id: Date.now(), text }]);
@@ -389,7 +400,14 @@ function App() {
           setAreaAliases={setAreaAliases}
           animDirection={weekAnim}
         />
-        <Notes notes={notes} onAdd={addNote} onDelete={deleteNote} />
+        <Notes
+          notes={notes}
+          onAdd={addNote}
+          onDelete={deleteNote}
+          areas={usedAreas}
+          areaAliases={areaAliases}
+          setAreaAliases={setAreaAliases}
+        />
       </div>
       <div
         className="resizer"

--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -1,7 +1,15 @@
 import React, { useState } from 'react';
 
-export default function Notes({ notes, onAdd, onDelete }) {
+export default function Notes({
+  notes,
+  onAdd,
+  onDelete,
+  areas = [],
+  areaAliases = {},
+  setAreaAliases,
+}) {
   const [value, setValue] = useState('');
+  const [tab, setTab] = useState('notes');
 
   const add = () => {
     const text = value.trim();
@@ -11,44 +19,94 @@ export default function Notes({ notes, onAdd, onDelete }) {
     }
   };
 
+  const updateAlias = (area, value) => {
+    if (!setAreaAliases) return;
+    if (value.trim() === '') {
+      const { [area]: _removed, ...rest } = areaAliases;
+      setAreaAliases(rest);
+    } else {
+      setAreaAliases({ ...areaAliases, [area]: value });
+    }
+  };
+
   return (
     <div className="mt-4 flex flex-col">
-      <h2 className="font-semibold mb-2">Notes</h2>
-      <div className="flex mb-2">
-        <input
-          type="text"
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && add()}
-          className="border flex-grow px-1 text-sm"
-        />
+      <div className="flex mb-2 space-x-2">
         <button
-          className="ml-2 px-2 py-1 bg-blue-500 text-white text-xs"
-          onClick={add}
+          className={`px-2 py-1 text-xs ${
+            tab === 'notes' ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-700'
+          }`}
+          onClick={() => setTab('notes')}
         >
-          Add
+          Notes
+        </button>
+        <button
+          className={`px-2 py-1 text-xs ${
+            tab === 'areas' ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-700'
+          }`}
+          onClick={() => setTab('areas')}
+        >
+          Custom Area Names
         </button>
       </div>
-      <div className="flex flex-wrap gap-1 overflow-y-auto max-h-40">
-        {notes.map((n) => (
-          <div
-            key={n.id}
-            className="px-2 py-1 border rounded-full bg-gray-200 dark:bg-gray-700 text-xs flex items-center"
-            draggable
-            onDragStart={(e) =>
-              e.dataTransfer.setData('application/x-note', JSON.stringify(n))
-            }
-          >
-            <span className="truncate mr-1">{n.text}</span>
+      {tab === 'notes' && (
+        <>
+          <div className="flex mb-2">
+            <input
+              type="text"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && add()}
+              className="border flex-grow px-1 text-sm"
+            />
             <button
-              className="ml-auto text-red-600 text-xs"
-              onClick={() => onDelete(n.id)}
+              className="ml-2 px-2 py-1 bg-blue-500 text-white text-xs"
+              onClick={add}
             >
-              x
+              Add
             </button>
           </div>
-        ))}
-      </div>
+          <div className="flex flex-wrap gap-1 overflow-y-auto max-h-40">
+            {notes.map((n) => (
+              <div
+                key={n.id}
+                className="px-2 py-1 border rounded-full bg-gray-200 dark:bg-gray-700 text-xs flex items-center"
+                draggable
+                onDragStart={(e) =>
+                  e.dataTransfer.setData('application/x-note', JSON.stringify(n))
+                }
+              >
+                <span className="truncate mr-1">{n.text}</span>
+                <button
+                  className="ml-auto text-red-600 text-xs"
+                  onClick={() => onDelete(n.id)}
+                >
+                  x
+                </button>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+      {tab === 'areas' && (
+        <div className="flex flex-col gap-1 overflow-y-auto max-h-40 text-xs">
+          {areas.map((area) => (
+            <div key={area} className="flex items-center gap-1">
+              <span className="truncate w-1/2" title={area}>{area}</span>
+              <input
+                type="text"
+                className="border flex-grow px-1"
+                value={areaAliases[area] || ''}
+                onChange={(e) => updateAlias(area, e.target.value)}
+                placeholder="Custom name"
+              />
+            </div>
+          ))}
+          {areas.length === 0 && (
+            <span className="text-xs text-gray-500">No areas yet</span>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `Custom Area Names` tab to `Notes` for easier area alias editing
- compute used areas from work blocks and pass them to `Notes`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849de05c740832382036d5384cb0014