### PR TITLE
Cache all fetched workitems

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -94,16 +94,9 @@ function App() {
     const since = lastFetch ? new Date(lastFetch) : null;
     service.getWorkItems(since).then((data) => {
       setItems((prev) => {
-        const map = new Map(data.map((i) => [i.id, i]));
-        const blockIds = new Set();
-        blocks.forEach((b) => {
-          if (b.itemId) blockIds.add(b.itemId);
-          if (b.taskId) blockIds.add(b.taskId);
-        });
-        prev.forEach((i) => {
-          if (blockIds.has(i.id) && !map.has(i.id)) {
-            map.set(i.id, i);
-          }
+        const map = new Map(prev.map((i) => [i.id, i]));
+        data.forEach((item) => {
+          map.set(item.id, item);
         });
         return Array.from(map.values());
       });


### PR DESCRIPTION
## Summary
- keep previously fetched work items instead of only those used in calendar

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e1b18fd48323b2ca6e56ef0ee466