### PR TITLE
Improve work item refresh options

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,7 +73,7 @@ function App() {
     deleteNote(note.id);
   };
 
-  const fetchWorkItems = useCallback(() => {
+  const fetchWorkItems = useCallback((full = false) => {
     const {
       azureOrg,
       azurePat,
@@ -91,8 +91,14 @@ function App() {
       azureArea,
       azureIteration
     );
-    const since = lastFetch ? new Date(lastFetch) : null;
-    service.getWorkItems(since).then((data) => {
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    let days = null;
+    if (!full && lastFetch) {
+      const last = new Date(lastFetch);
+      days = Math.ceil((Date.now() - last.getTime()) / DAY_MS);
+      if (days === 0) days = 1;
+    }
+    service.getWorkItems(days).then((data) => {
       setItems((prev) => {
         const map = new Map(prev.map((i) => [i.id, i]));
         data.forEach((item) => {

--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -260,12 +260,20 @@ export default function WorkItems({
         <div className="flex items-center justify-between mb-1">
           <h2 className="font-semibold">Work Items</h2>
           {onRefresh && (
-            <button
-              className="px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700"
-              onClick={onRefresh}
-            >
-              Refresh
-            </button>
+            <div className="space-x-2">
+              <button
+                className="px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700"
+                onClick={() => onRefresh(false)}
+              >
+                Refresh
+              </button>
+              <button
+                className="px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700"
+                onClick={() => onRefresh(true)}
+              >
+                Full Refresh
+              </button>
+            </div>
           )}
         </div>
         <div className="flex space-x-2 mb-2">

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -21,7 +21,7 @@ export default class AdoService {
         : (str) => Buffer.from(str).toString('base64');
   }
 
-  _buildQuery(since = null) {
+  _buildQuery(days = null) {
     const projectFilter = this.projects.length
       ? `[System.TeamProject] in (${this.projects
           .map((p) => `'${p}'`)
@@ -36,8 +36,8 @@ export default class AdoService {
     const iterationFilter = this.iteration
       ? `[System.IterationPath] under '${this.iteration}' and `
       : '';
-    const dateFilter = since
-      ? `[System.ChangedDate] >= '${since.toISOString()}'`
+    const dateFilter = typeof days === 'number'
+      ? `[System.ChangedDate] >= @Today - ${days}`
       : '[System.ChangedDate] >= @Today - 30';
     return (
       'Select [System.Id] From WorkItems Where ' +
@@ -82,7 +82,7 @@ export default class AdoService {
     );
   }
 
-  async getWorkItems(since = null) {
+  async getWorkItems(days = null) {
     if (!this.org || !this.token) {
       return [];
     }
@@ -98,7 +98,7 @@ export default class AdoService {
             Authorization: auth,
           },
           body: JSON.stringify({
-            query: this._buildQuery(since),
+            query: this._buildQuery(days),
           }),
         }
       );


### PR DESCRIPTION
## Summary
- support limiting incremental refresh to last day and offer full refresh
- sanitize date used in WIQL query
- compute relative days for incremental refresh

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e3d7f4a4832382cfdf0170c61822