### PR TITLE
Enable double-click open for work items

### DIFF
--- a/src/components/WorkItem.jsx
+++ b/src/components/WorkItem.jsx
@@ -7,6 +7,7 @@ export default function WorkItem({
   onNoteDrop,
   highlight = false,
   pill = false,
+  onOpen,
 }) {
   const colors = {
     task: 'bg-yellow-100 dark:bg-yellow-700',
@@ -54,6 +55,11 @@ export default function WorkItem({
   const highlightClass = highlight ? 'ring-2 ring-red-500' : '';
   const asPill = pill;
 
+  const handleDoubleClick = (e) => {
+    e.stopPropagation();
+    if (onOpen) onOpen(item);
+  };
+
   return asPill ? (
     <div
       className={`inline-block task-pill px-2 py-1 ${colorClass} text-xs font-semibold mr-2 mb-2 ${highlightClass}`}
@@ -61,6 +67,7 @@ export default function WorkItem({
       onDragStart={dragStart}
       onDragOver={allowDrop}
       onDrop={handleDrop}
+      onDoubleClick={handleDoubleClick}
       title={item.title}
       style={{ marginLeft: `${level * 0.5}rem` }}
     >
@@ -80,6 +87,7 @@ export default function WorkItem({
       onDragStart={dragStart}
       onDragOver={allowDrop}
       onDrop={handleDrop}
+      onDoubleClick={handleDoubleClick}
       className={`p-1 mb-1 border ${colorClass} text-xs truncate ${highlightClass}`}
       style={{ marginLeft: `${level * 1}rem` }}
       title={item.title}

--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -24,7 +24,8 @@ function renderTree(
   notesMap,
   highlightIds,
   featureCollapsed,
-  toggleFeature
+  toggleFeature,
+  openItem
 ) {
   return nodes.map((node) => {
     const isFeature = node.type?.toLowerCase() === 'feature';
@@ -40,6 +41,7 @@ function renderTree(
             onNoteDrop={onNoteDrop}
             highlight={highlightIds?.has(node.id)}
             pill={node.type?.toLowerCase() === 'task' && level > 0}
+            onOpen={openItem}
           />
           {isFeature && node.children.length > 0 && (
             <span className="ml-1 text-xs">{collapsed ? '▶' : '▼'}</span>
@@ -53,7 +55,8 @@ function renderTree(
             notesMap,
             highlightIds,
             featureCollapsed,
-            toggleFeature
+            toggleFeature,
+            openItem
           )}
       </div>
     );
@@ -252,6 +255,19 @@ export default function WorkItems({
     const value = settings.azureIteration === it ? '' : it;
     // Update local filter state without refetching.
     updateSettings({ azureIteration: value });
+  };
+
+  const openItem = (item) => {
+    const org = settings.azureOrg;
+    const url = org
+      ? `https://dev.azure.com/${org}/_workitems/edit/${item.id}`
+      : `https://dev.azure.com/_workitems/edit/${item.id}`;
+    const payload = { id: item.id, hours: 0, days: {}, url };
+    if (window.api && window.api.openWorkItems) {
+      window.api.openWorkItems([payload]);
+    } else {
+      window.open(url, '_blank');
+    }
   };
 
   return (
@@ -482,7 +498,8 @@ export default function WorkItems({
                     itemNotes,
                     highlightedIds,
                     featureCollapsed,
-                    toggleFeature
+                    toggleFeature,
+                    openItem
                   )}
                 </div>
               )}


### PR DESCRIPTION
## Summary
- open work item detail when double-clicked in the Work Items list
- pass handler through WorkItems tree to `WorkItem`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e7df39948323adba19e8b1b1d3c8