### PR TITLE
Filter out test case work items

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ This command first builds the React app and then packages the Electron applicati
 
 Only **Tasks** and **Bugs/Transversal Activities** can be scheduled directly on the calendar. Items like **Features** and **User Stories** act as containers and must have child tasks created before you can plan them. Work items are color coded by type (e.g., yellow for tasks, red for bugs, purple for features) so you can quickly distinguish them. This restriction keeps effort reporting aligned at the task level in ADO.
 
+Test Case and Test Suite work items are ignored and will not appear in the work item list.
+
 
 ## License
 

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -36,6 +36,8 @@ export default class AdoService {
     const iterationFilter = this.iteration
       ? `[System.IterationPath] under '${this.iteration}' and `
       : '';
+    const typeFilter =
+      "[System.WorkItemType] not in ('Test Case','Test Suite') and ";
     const dateFilter = since
       ? `[System.ChangedDate] >= '${since.toISOString().split('T')[0]}'`
       : '[System.ChangedDate] >= @Today - 30';
@@ -45,6 +47,7 @@ export default class AdoService {
       tagFilter +
       areaFilter +
       iterationFilter +
+      typeFilter +
       `${dateFilter} order by [System.ChangedDate] desc`
     );
   }


### PR DESCRIPTION
## Summary
- filter out Test Case and Test Suite from fetched work items
- document that these items are omitted from the work item list

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ecf9503c83238ca38d8f86fbef8c