### PR TITLE
Remove unused area/iteration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 * Weekly summary panel
 * Displays total hours for the current week with red text when exceeding 40 hours
 * Bulk submit to ADO with preview
-* Warnings if area path is missing or invalid
 * Option to export week as CSV for backup
 
 ### 3.6 Advanced Suggestions (Optional Phase 2)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -348,14 +348,8 @@ function App() {
     settings.azureArea,
     settings.azureIteration
   );
-  const missingArea = reviewService.findMissingArea(items);
-  const missingIteration = reviewService.findMissingIteration(items);
   const treeProblems = reviewService.findTreeProblems(items);
-  const highlightedIds = new Set([
-    ...missingArea.map((i) => i.id),
-    ...missingIteration.map((i) => i.id),
-    ...treeProblems.map((i) => i.id),
-  ]);
+  const highlightedIds = new Set(treeProblems.map((i) => i.id));
 
   return (
     <div

--- a/src/components/DevOpsReview.jsx
+++ b/src/components/DevOpsReview.jsx
@@ -11,8 +11,6 @@ export default function DevOpsReview({ items = [], settings }) {
     settings.azureIteration
   );
 
-  const missingArea = service.findMissingArea(items);
-  const missingIteration = service.findMissingIteration(items);
   const treeProblems = service.findTreeProblems(items);
 
   const renderList = (list) => (
@@ -30,18 +28,6 @@ export default function DevOpsReview({ items = [], settings }) {
     <div className="flex flex-col h-full overflow-y-auto">
       <h2 className="font-semibold mb-2">DevOps Review</h2>
       <div className="space-y-4">
-        <div>
-          <div className="font-semibold text-sm">
-            Missing Area Path ({missingArea.length})
-          </div>
-          {missingArea.length > 0 && renderList(missingArea)}
-        </div>
-        <div>
-          <div className="font-semibold text-sm">
-            Missing Iteration ({missingIteration.length})
-          </div>
-          {missingIteration.length > 0 && renderList(missingIteration)}
-        </div>
         <div>
           <div className="font-semibold text-sm">
             DevOps Tree Problems ({treeProblems.length})

--- a/src/components/HoursSummary.jsx
+++ b/src/components/HoursSummary.jsx
@@ -29,27 +29,13 @@ export default function HoursSummary({ blocks, weekStart, items }) {
       return sum + diff;
     }, 0);
 
-  const misconfiguredHours = blocks
-    .filter((b) => {
-      const start = new Date(b.start);
-      if (!(start >= weekStart && start < weekEnd && b.taskId)) return false;
-      const task = items?.find((i) => i.id === b.taskId);
-      return !task || !task.area;
-    })
-    .reduce((sum, b) => {
-      const start = new Date(b.start);
-      const end = new Date(b.end);
-      const diff = (end - start) / (1000 * 60 * 60);
-      return sum + diff;
-    }, 0);
-  const correctAssigned = Math.max(assignedHours - misconfiguredHours, 0);
+  const correctAssigned = assignedHours;
 
   const overLimit = totalHours > WEEK_LIMIT;
   const textColor = overLimit ? 'text-red-600' : 'text-gray-800 dark:text-gray-200';
 
   const totalPercent = Math.min(totalHours, WEEK_LIMIT) / WEEK_LIMIT * 100;
   const assignedPercent = Math.min(correctAssigned, WEEK_LIMIT) / WEEK_LIMIT * 100;
-  const misconfiguredPercent = Math.min(misconfiguredHours, WEEK_LIMIT) / WEEK_LIMIT * 100;
 
   const [showDetails, setShowDetails] = useState(false);
 
@@ -68,23 +54,15 @@ export default function HoursSummary({ blocks, weekStart, items }) {
           className="absolute inset-0 bg-green-500 progress-segment"
           style={{ width: `${assignedPercent}%` }}
         />
-        <div
-          className="absolute inset-0 bg-red-500 progress-segment"
-          style={{ width: `${misconfiguredPercent}%` }}
-        />
         {showDetails && (
           <div className="hours-tooltip fade-in">
             {totalHours.toFixed(1)}h total / {correctAssigned.toFixed(1)}h linked
-            {misconfiguredHours > 0 && `, ${misconfiguredHours.toFixed(1)}h missing area`}
           </div>
         )}
       </div>
       <div className="flex justify-between text-xs mt-1">
         <span className={textColor}>{totalHours.toFixed(1)}h/{WEEK_LIMIT}</span>
         <span className="text-green-600">{correctAssigned.toFixed(1)}h</span>
-        {misconfiguredHours > 0 && (
-          <span className="text-red-600">{misconfiguredHours.toFixed(1)}h</span>
-        )}
       </div>
     </div>
   );

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -148,13 +148,6 @@ export default class AdoService {
     }
   }
 
-  findMissingArea(items = []) {
-    return items.filter((i) => !(i.area && i.area.trim()));
-  }
-
-  findMissingIteration(items = []) {
-    return items.filter((i) => !(i.iteration && i.iteration.trim()));
-  }
 
   findIncorrectState(items = [], validStates = []) {
     if (!Array.isArray(validStates) || validStates.length === 0) return [];


### PR DESCRIPTION
## Summary
- drop warnings about missing area path and iteration
- simplify hours summary logic
- trim DevOps review output

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b122cf264832384fd2f8354b32aa0