### PR TITLE
Add acceptance criteria check

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 * Displays total hours for the current week with red text when exceeding 40 hours
 * Bulk submit to ADO with preview
 * Option to export week as CSV for backup
+* DevOps Review panel highlights missing acceptance criteria
 
 ### 3.6 Advanced Suggestions (Optional Phase 2)
 

--- a/__tests__/acceptanceCriteria.test.js
+++ b/__tests__/acceptanceCriteria.test.js
@@ -1,0 +1,14 @@
+const AdoService = require('../src/services/adoService.js').default;
+
+test('finds items missing acceptance criteria', () => {
+  const svc = new AdoService();
+  const items = [
+    { id: '1', title: 'Story complete', acceptanceCriteria: 'done' },
+    { id: '2', title: 'Story missing', acceptanceCriteria: '' },
+    { id: '3', title: 'Story null' },
+  ];
+  const missing = svc.findMissingAcceptanceCriteria(items);
+  const ids = missing.map(i => i.id);
+  expect(ids).toEqual(expect.arrayContaining(['2', '3']));
+  expect(ids).not.toContain('1');
+});

--- a/src/components/DevOpsReview.jsx
+++ b/src/components/DevOpsReview.jsx
@@ -12,6 +12,7 @@ export default function DevOpsReview({ items = [], settings }) {
   );
 
   const treeProblems = service.findTreeProblems(items);
+  const missingAcceptance = service.findMissingAcceptanceCriteria(items);
 
   const renderList = (list) => (
     <ul className="ml-4 list-disc text-xs mt-1">
@@ -33,6 +34,12 @@ export default function DevOpsReview({ items = [], settings }) {
             DevOps Tree Problems ({treeProblems.length})
           </div>
           {treeProblems.length > 0 && renderList(treeProblems)}
+        </div>
+        <div>
+          <div className="font-semibold text-sm">
+            Missing Acceptance Criteria ({missingAcceptance.length})
+          </div>
+          {missingAcceptance.length > 0 && renderList(missingAcceptance)}
         </div>
       </div>
     </div>

--- a/src/models/workItem.js
+++ b/src/models/workItem.js
@@ -9,6 +9,11 @@ export default class WorkItem {
     area = '',
     iteration = '',
     state = '',
+    startDate = '',
+    targetDate = '',
+    storyPoints = null,
+    acceptanceCriteria = '',
+    dependencies = [],
   }) {
     this.id = id;
     this.title = title;
@@ -19,5 +24,10 @@ export default class WorkItem {
     this.area = area;
     this.iteration = iteration;
     this.state = state;
+    this.startDate = startDate;
+    this.targetDate = targetDate;
+    this.storyPoints = storyPoints;
+    this.acceptanceCriteria = acceptanceCriteria;
+    this.dependencies = dependencies;
   }
 }


### PR DESCRIPTION
## Summary
- fetch extra fields from DevOps API
- store start/target dates, story points and acceptance criteria in WorkItem model
- expose dependencies and add service helper to find items missing acceptance criteria
- show missing acceptance criteria in DevOps Review panel
- document the new DevOps Review behaviour
- test missing acceptance criteria helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b140217dc8323bdd100c4c1b8aa9a