### PR TITLE
Fix bug relation check and batch fetch

### DIFF
--- a/__tests__/treeProblems.test.js
+++ b/__tests__/treeProblems.test.js
@@ -10,17 +10,20 @@ test('detects invalid hierarchy', () => {
     { id: '5', title: 'Story ok', type: 'User Story', parentId: '3' },
     { id: '6', title: 'Task bad parent', type: 'Task', parentId: '3' },
     { id: '7', title: 'Task ok', type: 'Task', parentId: '5' },
-    { id: '8', title: 'Bug wrong parent', type: 'Bug', parentId: '5' },
-    { id: '9', title: 'Bug ok', type: 'Bug', parentId: '3' },
-    { id: '10', title: 'Transversal bad', type: 'Transversal Activity', parentId: '5' },
-    { id: '11', title: 'Transversal ok', type: 'Transversal Activity', parentId: '3' },
+    { id: '8', title: 'Bug missing relation', type: 'Bug' },
+    { id: '9', title: 'Bug wrong relation type', type: 'Bug', dependencies: ['7'] },
+    { id: '10', title: 'Bug ok story relation', type: 'Bug', dependencies: ['5'] },
+    { id: '11', title: 'Bug ok feature relation', type: 'Bug', dependencies: ['3'] },
+    { id: '12', title: 'Transversal bad', type: 'Transversal Activity', parentId: '5' },
+    { id: '13', title: 'Transversal ok', type: 'Transversal Activity', parentId: '3' },
   ];
   const problems = svc.findTreeProblems(items);
   const ids = problems.map(p => p.id);
-  expect(ids).toEqual(expect.arrayContaining(['2', '4', '6', '8', '10']));
+  expect(ids).toEqual(expect.arrayContaining(['2', '4', '6', '8', '9', '12']));
   expect(ids).not.toContain('3');
   expect(ids).not.toContain('5');
   expect(ids).not.toContain('7');
-  expect(ids).not.toContain('9');
+  expect(ids).not.toContain('10');
   expect(ids).not.toContain('11');
+  expect(ids).not.toContain('13');
 });


### PR DESCRIPTION
## Summary
- use the work items batch API to retrieve relations
- update bug hierarchy check to verify relation to user stories or features
- adjust treeProblems tests for new bug rule

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b21c1adbc8323849b2a5a45b7be73