### PR TITLE
Add toggle for DevOps review features

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 * Displays total hours for the current week with red text when exceeding 40 hours
 * Bulk submit to ADO with preview
 * Option to export week as CSV for backup
-* DevOps Review panel highlights missing acceptance criteria
+* DevOps Review panel (disabled by default) highlights missing acceptance criteria and requires relations API; enable it under settings
 
 ### 3.6 Advanced Suggestions (Optional Phase 2)
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -89,7 +89,8 @@ function App() {
       azureProjects,
       azureTags,
       azureArea,
-      azureIteration
+      azureIteration,
+      settings.enableDevOpsReview
     );
     let since = null;
     if (!full) {
@@ -351,9 +352,12 @@ function App() {
     settings.azureProjects,
     settings.azureTags,
     settings.azureArea,
-    settings.azureIteration
+    settings.azureIteration,
+    settings.enableDevOpsReview
   );
-  const treeProblems = reviewService.findTreeProblems(items);
+  const treeProblems = settings.enableDevOpsReview
+    ? reviewService.findTreeProblems(items)
+    : [];
   const highlightedIds = new Set(treeProblems.map((i) => i.id));
 
   return (
@@ -443,16 +447,18 @@ function App() {
           >
             Work Items
           </button>
-          <button
-            className={`px-2 py-1 text-xs ${
-              panelTab === 'review'
-                ? 'bg-blue-500 text-white'
-                : 'bg-gray-200 dark:bg-gray-700'
-            }`}
-            onClick={() => setPanelTab('review')}
-          >
-            DevOps Review
-          </button>
+          {settings.enableDevOpsReview && (
+            <button
+              className={`px-2 py-1 text-xs ${
+                panelTab === 'review'
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-200 dark:bg-gray-700'
+              }`}
+              onClick={() => setPanelTab('review')}
+            >
+              DevOps Review
+            </button>
+          )}
         </div>
         {panelTab === 'workItems' && (
           <WorkItems
@@ -466,7 +472,7 @@ function App() {
             highlightedIds={highlightedIds}
           />
         )}
-        {panelTab === 'review' && (
+        {panelTab === 'review' && settings.enableDevOpsReview && (
           <DevOpsReview items={items} settings={settings} />
         )}
       </div>

--- a/src/components/DevOpsReview.jsx
+++ b/src/components/DevOpsReview.jsx
@@ -8,7 +8,8 @@ export default function DevOpsReview({ items = [], settings }) {
     settings.azureProjects,
     settings.azureTags,
     settings.azureArea,
-    settings.azureIteration
+    settings.azureIteration,
+    true
   );
 
   const treeProblems = service.findTreeProblems(items);

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -317,12 +317,27 @@ export default function Settings({ settings, setSettings }) {
                             .filter((s) => s),
                         })
                       }
-                      className="border w-full px-1"
+                    className="border w-full px-1"
+                  />
+                </div>
+                <div className="flex items-center space-x-2 mt-1">
+                  <label className="flex items-center space-x-1">
+                    <input
+                      type="checkbox"
+                      checked={temp.enableDevOpsReview}
+                      onChange={() =>
+                        setTemp({
+                          ...temp,
+                          enableDevOpsReview: !temp.enableDevOpsReview,
+                        })
+                      }
                     />
-                  </div>
-                </>
-              )}
-              <div className="flex space-x-2 pt-2">
+                    <span>Enable DevOps Review</span>
+                  </label>
+                </div>
+              </>
+            )}
+            <div className="flex space-x-2 pt-2">
                 <button className="px-2 py-1 bg-blue-500 text-white text-xs" onClick={save}>
                   Save
                 </button>

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -19,6 +19,7 @@ const defaultSettings = {
   azureIteration: '',
   sidebarWidth: 320,
   enableReminders: true,
+  enableDevOpsReview: false,
   stateOrder: [
     'New',
     'Ready',

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -7,7 +7,8 @@ export default class AdoService {
     projects = [],
     tags = [],
     area = '',
-    iteration = ''
+    iteration = '',
+    includeRelations = false
   ) {
     this.org = org;
     this.token = token;
@@ -15,6 +16,7 @@ export default class AdoService {
     this.tags = tags;
     this.area = area;
     this.iteration = iteration;
+    this.includeRelations = includeRelations;
     this._b64 =
       typeof btoa === 'function'
         ? (str) => btoa(str)
@@ -169,7 +171,10 @@ export default class AdoService {
       for (let i = 0; i < ids.length; i += 200) {
         const batchIds = ids.slice(i, i + 200);
         const items = await this._fetchItems(batchIds, auth);
-        const deps = await this._fetchRelations(batchIds, auth);
+        let deps = {};
+        if (this.includeRelations) {
+          deps = await this._fetchRelations(batchIds, auth);
+        }
         items.forEach((it) => {
           it.dependencies = deps[it.id] || [];
         });
@@ -186,7 +191,10 @@ export default class AdoService {
       while (missing.size > 0) {
         const batch = Array.from(missing).slice(0, 200);
         const parents = await this._fetchItems(batch, auth);
-        const parentDeps = await this._fetchRelations(batch, auth);
+        let parentDeps = {};
+        if (this.includeRelations) {
+          parentDeps = await this._fetchRelations(batch, auth);
+        }
         parents.forEach((p) => {
           p.dependencies = parentDeps[p.id] || [];
           if (!map.has(p.id)) {


### PR DESCRIPTION
## Summary
- add `enableDevOpsReview` to settings
- allow enabling DevOps Review tab and relations API through settings
- skip relations API calls when feature disabled
- document that DevOps Review is off by default

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0b0ab5dc8323809918f4a8c11f21