### PR TITLE
Handle failed API requests

### DIFF
--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -280,13 +280,13 @@ export default function WorkItems({
             <div className="space-x-2">
               <button
                 className="px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700"
-                onClick={() => onRefresh(false)}
+                onClick={() => onRefresh(false, true)}
               >
                 Refresh
               </button>
               <button
                 className="px-2 py-1 text-xs bg-gray-200 dark:bg-gray-700"
-                onClick={() => onRefresh(true)}
+                onClick={() => onRefresh(true, true)}
               >
                 Full Refresh
               </button>

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -81,7 +81,7 @@ export default class AdoService {
       },
     });
     if (!res.ok) {
-      return [];
+      throw new Error('Failed to fetch items');
     }
 
     const data = await res.json();
@@ -121,7 +121,7 @@ export default class AdoService {
       },
     });
     if (!res.ok) {
-      return {};
+      throw new Error('Failed to fetch relations');
     }
 
     const data = await res.json();
@@ -144,8 +144,7 @@ export default class AdoService {
     }
 
     const auth = `Basic ${this._b64(':' + this.token)}`;
-    try {
-      const wiqlRes = await fetch(
+    const wiqlRes = await fetch(
         `https://dev.azure.com/${this.org}/_apis/wit/wiql?api-version=7.0`,
         {
           method: 'POST',
@@ -159,9 +158,9 @@ export default class AdoService {
         }
       );
 
-      if (!wiqlRes.ok) {
-        return [];
-      }
+    if (!wiqlRes.ok) {
+      throw new Error('Failed to query work items');
+    }
 
       const wiql = await wiqlRes.json();
       const ids = wiql.workItems.map((w) => w.id);
@@ -206,11 +205,7 @@ export default class AdoService {
         });
       }
 
-      return Array.from(map.values());
-    } catch (e) {
-      console.error('Failed to fetch work items', e);
-      return [];
-    }
+    return Array.from(map.values());
   }
 
   findMissingAcceptanceCriteria(items = []) {


### PR DESCRIPTION
## Summary
- detect API failures in adoService
- block automatic refresh attempts until a manual refresh
- pass manual refresh flag from WorkItems

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0e4f31e08323ade3c0a6ea771a97