### PR TITLE
Add starred notes feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 4. System suggests work items; user confirms or drags a task manually.
 5. User can click a task to auto-link it to selected time block.
 6. Notes appear as draggable comment pills that can be dropped into work blocks.
+   Star a note to keep it available after dropping.
 
 ### 4.2 Review & Submit
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,12 @@ function App() {
   }, [blocks, items]);
 
   const addNote = (text) =>
-    setNotes((prev) => [...prev, { id: Date.now(), text }]);
+    setNotes((prev) => [...prev, { id: Date.now(), text, starred: false }]);
+
+  const toggleNoteStar = (id) =>
+    setNotes((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, starred: !n.starred } : n))
+    );
 
   const deleteNote = (id) =>
     setNotes((prev) => prev.filter((n) => n.id !== id));
@@ -60,7 +65,7 @@ function App() {
       const list = prev[itemId] ? [...prev[itemId], note.text] : [note.text];
       return { ...prev, [itemId]: list };
     });
-    deleteNote(note.id);
+    if (!note.starred) deleteNote(note.id);
   };
 
   const handleBlockCommentDrop = (blockId, note) => {
@@ -71,7 +76,7 @@ function App() {
           : b
       )
     );
-    deleteNote(note.id);
+    if (!note.starred) deleteNote(note.id);
   };
 
   const fetchWorkItems = useCallback(async (full = false, fromUser = false) => {
@@ -420,6 +425,7 @@ function App() {
           notes={notes}
           onAdd={addNote}
           onDelete={deleteNote}
+          onToggleStar={toggleNoteStar}
           areas={usedAreas}
           areaAliases={areaAliases}
           setAreaAliases={setAreaAliases}

--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -4,6 +4,7 @@ export default function Notes({
   notes,
   onAdd,
   onDelete,
+  onToggleStar,
   areas = [],
   areaAliases = {},
   setAreaAliases,
@@ -76,6 +77,13 @@ export default function Notes({
                   e.dataTransfer.setData('application/x-note', JSON.stringify(n))
                 }
               >
+                <button
+                  className="mr-1 text-yellow-500"
+                  onClick={() => onToggleStar && onToggleStar(n.id)}
+                  title={n.starred ? 'Unstar' : 'Star'}
+                >
+                  {n.starred ? '★' : '☆'}
+                </button>
                 <span className="truncate mr-1">{n.text}</span>
                 <button
                   className="ml-auto text-red-600 text-xs"

--- a/src/hooks/useNotes.js
+++ b/src/hooks/useNotes.js
@@ -8,7 +8,8 @@ export default function useNotes() {
   useEffect(() => {
     const storage = new StorageService('notes', { notes: [], itemNotes: {} });
     const data = storage.read();
-    setNotes(data.notes || []);
+    const loaded = (data.notes || []).map((n) => ({ starred: false, ...n }));
+    setNotes(loaded);
     setItemNotes(data.itemNotes || {});
   }, []);
 


### PR DESCRIPTION
## Summary
- let Notes be starred so they persist after being dropped
- keep star information in storage
- update `Notes` UI with star toggle
- document starring notes in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853188270588323ab32712dc70e5ea4