### PR TITLE
Highlight missing story points

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 * Displays total hours for the current week with red text when exceeding 40 hours
 * Bulk submit to ADO with preview
 * Option to export week as CSV for backup
-* DevOps Review panel (disabled by default) highlights missing acceptance criteria and requires relations API; enable it under settings
+* DevOps Review panel (disabled by default) highlights missing acceptance criteria and story points and requires relations API; enable it under settings
 
 ### 3.6 Advanced Suggestions (Optional Phase 2)
 

--- a/__tests__/storyPoints.test.js
+++ b/__tests__/storyPoints.test.js
@@ -1,0 +1,18 @@
+const AdoService = require('../src/services/adoService.js').default;
+
+test('finds items missing story points', () => {
+  const svc = new AdoService();
+  const items = [
+    { id: '1', type: 'Feature', storyPoints: 5 },
+    { id: '2', type: 'Feature' },
+    { id: '3', type: 'User Story', storyPoints: null },
+    { id: '4', type: 'Bug', storyPoints: 3 },
+    { id: '5', type: 'Task' },
+  ];
+  const missing = svc.findMissingStoryPoints(items);
+  const ids = missing.map(i => i.id);
+  expect(ids).toEqual(expect.arrayContaining(['2', '3']));
+  expect(ids).not.toContain('1');
+  expect(ids).not.toContain('4');
+  expect(ids).not.toContain('5');
+});

--- a/src/components/DevOpsReview.jsx
+++ b/src/components/DevOpsReview.jsx
@@ -14,6 +14,7 @@ export default function DevOpsReview({ items = [], settings }) {
 
   const treeProblems = service.findTreeProblems(items);
   const missingAcceptance = service.findMissingAcceptanceCriteria(items);
+  const missingStoryPoints = service.findMissingStoryPoints(items);
 
   const renderList = (list) => (
     <ul className="ml-4 list-disc text-xs mt-1">
@@ -41,6 +42,12 @@ export default function DevOpsReview({ items = [], settings }) {
             Missing Acceptance Criteria ({missingAcceptance.length})
           </div>
           {missingAcceptance.length > 0 && renderList(missingAcceptance)}
+        </div>
+        <div>
+          <div className="font-semibold text-sm">
+            Missing Story Points ({missingStoryPoints.length})
+          </div>
+          {missingStoryPoints.length > 0 && renderList(missingStoryPoints)}
         </div>
       </div>
     </div>

--- a/src/services/adoService.js
+++ b/src/services/adoService.js
@@ -222,6 +222,20 @@ export default class AdoService {
     );
   }
 
+  findMissingStoryPoints(items = [], types = [
+    'feature',
+    'user story',
+    'evolution',
+    'bug',
+  ]) {
+    const allowed = types.map((t) => t.toLowerCase());
+    return items.filter(
+      (i) =>
+        allowed.includes((i.type || '').toLowerCase()) &&
+        (i.storyPoints === undefined || i.storyPoints === null)
+    );
+  }
+
   findTreeProblems(items = []) {
     const map = new Map(items.map((i) => [i.id, i]));
     const issues = [];


### PR DESCRIPTION
## Summary
- add `findMissingStoryPoints` helper
- display missing story points in DevOps Review panel
- note missing story points in README
- test finding work items without story points

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685318ba7b2c8323be4a77a04baa29bb