### PR TITLE
Group unparented work items under placeholders

### DIFF
--- a/__tests__/treePlaceholder.test.js
+++ b/__tests__/treePlaceholder.test.js
@@ -1,0 +1,28 @@
+const { buildTree } = require('../src/components/WorkItems.jsx');
+
+test('creates placeholders for missing parents', () => {
+  const items = [
+    { id: '1', title: 'Lonely Feature', type: 'Feature' },
+    { id: '2', title: 'Lonely Story', type: 'User Story' },
+    { id: '3', title: 'Epic', type: 'Epic' },
+    { id: '4', title: 'Child Feature', type: 'Feature', parentId: '3' },
+  ];
+  const tree = buildTree(items);
+  const epicPh = tree.find((n) => n.id === '__placeholder_epic__');
+  const featurePh = tree.find((n) => n.id === '__placeholder_feature__');
+  expect(epicPh.children.map((c) => c.id)).toContain('1');
+  expect(featurePh.children.map((c) => c.id)).toContain('2');
+  expect(tree.some((n) => n.id === '3')).toBe(true);
+});
+
+test('omits placeholders when not needed', () => {
+  const items = [
+    { id: '10', title: 'Epic', type: 'Epic' },
+    { id: '11', title: 'Feature', type: 'Feature', parentId: '10' },
+  ];
+  const tree = buildTree(items);
+  const hasEpicPh = tree.some((n) => n.id === '__placeholder_epic__');
+  const hasFeaturePh = tree.some((n) => n.id === '__placeholder_feature__');
+  expect(hasEpicPh).toBe(false);
+  expect(hasFeaturePh).toBe(false);
+});

--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -1,19 +1,44 @@
 import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import WorkItem from './WorkItem';
 
-function buildTree(items) {
+export function buildTree(items) {
   const map = new Map();
   items.forEach((item) => {
     map.set(item.id, { ...item, children: [] });
   });
+
+  const placeholderEpic = {
+    id: '__placeholder_epic__',
+    title: 'Unassigned (No Epic)',
+    type: 'Epic',
+    children: [],
+  };
+  const placeholderFeature = {
+    id: '__placeholder_feature__',
+    title: 'Unassigned (No Feature)',
+    type: 'Feature',
+    children: [],
+  };
+
   const roots = [];
   map.forEach((item) => {
     if (item.parentId && map.has(item.parentId)) {
       map.get(item.parentId).children.push(item);
     } else {
-      roots.push(item);
+      const type = (item.type || '').toLowerCase();
+      if (type === 'feature') {
+        placeholderEpic.children.push(item);
+      } else if (type === 'epic') {
+        roots.push(item);
+      } else {
+        placeholderFeature.children.push(item);
+      }
     }
   });
+
+  if (placeholderEpic.children.length > 0) roots.push(placeholderEpic);
+  if (placeholderFeature.children.length > 0) roots.push(placeholderFeature);
+
   return roots;
 }
 


### PR DESCRIPTION
## Summary
- show missing parents in work item tree
- add tests for placeholder nodes when parents are missing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853191488bc8323ad87c389b168d05d