### PR TITLE
Add description and acceptance criteria checks

### DIFF
--- a/__tests__/acceptanceCriteria.test.js
+++ b/__tests__/acceptanceCriteria.test.js
@@ -1,14 +1,16 @@
 const AdoService = require('../src/services/adoService.js').default;
 
-test('finds items missing acceptance criteria', () => {
+test('finds items with missing or short acceptance criteria', () => {
   const svc = new AdoService();
   const items = [
-    { id: '1', title: 'Story complete', acceptanceCriteria: 'done' },
-    { id: '2', title: 'Story missing', acceptanceCriteria: '' },
-    { id: '3', title: 'Story null' },
+    { id: '1', type: 'User Story', acceptanceCriteria: 'complete work to spec' },
+    { id: '2', type: 'User Story', acceptanceCriteria: '' },
+    { id: '3', type: 'User Story', acceptanceCriteria: 'too short' },
+    { id: '4', type: 'Task', acceptanceCriteria: '' },
   ];
-  const missing = svc.findMissingAcceptanceCriteria(items);
-  const ids = missing.map(i => i.id);
+  const missing = svc.findMissingAcceptanceCriteria(items, 20, ['User Story']);
+  const ids = missing.map((i) => i.id);
   expect(ids).toEqual(expect.arrayContaining(['2', '3']));
   expect(ids).not.toContain('1');
+  expect(ids).not.toContain('4');
 });

--- a/__tests__/description.test.js
+++ b/__tests__/description.test.js
@@ -1,0 +1,16 @@
+const AdoService = require('../src/services/adoService.js').default;
+
+test('finds items with missing or short descriptions', () => {
+  const svc = new AdoService();
+  const items = [
+    { id: '1', type: 'Feature', description: 'This description is long enough to pass the check.' },
+    { id: '2', type: 'Feature', description: '' },
+    { id: '3', type: 'Feature', description: 'Too short' },
+    { id: '4', type: 'Task', description: '' },
+  ];
+  const missing = svc.findMissingOrShortDescription(items);
+  const ids = missing.map(i => i.id);
+  expect(ids).toEqual(expect.arrayContaining(['2', '3']));
+  expect(ids).not.toContain('1');
+  expect(ids).not.toContain('4');
+});

--- a/src/components/DevOpsReview.jsx
+++ b/src/components/DevOpsReview.jsx
@@ -13,7 +13,12 @@ export default function DevOpsReview({ items = [], settings }) {
   );
 
   const treeProblems = service.findTreeProblems(items);
-  const missingAcceptance = service.findMissingAcceptanceCriteria(items);
+  const shortDescriptions = service.findMissingOrShortDescription(items);
+  const shortAcceptance = service.findMissingAcceptanceCriteria(
+    items,
+    20,
+    ['feature', 'user story', 'evolution']
+  );
   const missingStoryPoints = service.findMissingStoryPoints(items);
 
   const renderList = (list) => (
@@ -39,9 +44,15 @@ export default function DevOpsReview({ items = [], settings }) {
         </div>
         <div>
           <div className="font-semibold text-sm">
-            Missing Acceptance Criteria ({missingAcceptance.length})
+            Missing or Short Description ({shortDescriptions.length})
           </div>
-          {missingAcceptance.length > 0 && renderList(missingAcceptance)}
+          {shortDescriptions.length > 0 && renderList(shortDescriptions)}
+        </div>
+        <div>
+          <div className="font-semibold text-sm">
+            Missing or Short Acceptance Criteria ({shortAcceptance.length})
+          </div>
+          {shortAcceptance.length > 0 && renderList(shortAcceptance)}
         </div>
         <div>
           <div className="font-semibold text-sm">

--- a/src/models/workItem.js
+++ b/src/models/workItem.js
@@ -2,6 +2,7 @@ export default class WorkItem {
   constructor({
     id,
     title,
+    description = '',
     type = 'task',
     parentId = null,
     project = '',
@@ -15,6 +16,7 @@ export default class WorkItem {
   }) {
     this.id = id;
     this.title = title;
+    this.description = description;
     this.type = type;
     this.parentId = parentId;
     this.project = project;


### PR DESCRIPTION
## Summary
- track work item description
- fetch description from DevOps
- add utility to find missing/short descriptions
- extend acceptance criteria checks with length rule
- update DevOps Review panel to show new sections
- update tests and add coverage for descriptions

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531bd114908323a6f615db28994c6c