### PR TITLE
Add devops issue banners and refine hours submission

### DIFF
--- a/src/components/WorkItems.jsx
+++ b/src/components/WorkItems.jsx
@@ -101,6 +101,7 @@ export default function WorkItems({
   onNoteDrop,
   itemNotes = {},
   highlightedIds = new Set(),
+  problems = new Map(),
 }) {
 
   const [search, setSearch] = useState('');
@@ -291,7 +292,11 @@ export default function WorkItems({
     const url = org
       ? `https://dev.azure.com/${org}/_workitems/edit/${item.id}`
       : `https://dev.azure.com/_workitems/edit/${item.id}`;
-    const payload = { id: item.id, hours: 0, days: {}, url, message };
+    let msg = message || '';
+    if (problems.has(item.id)) {
+      msg = msg ? `${msg} ${problems.get(item.id)}` : problems.get(item.id);
+    }
+    const payload = { id: item.id, hours: 0, days: [], url, message: msg };
     if (window.api && window.api.openWorkItems) {
       window.api.openWorkItems([payload]);
     } else {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -31,6 +31,20 @@ function openWorkItemWindow({ id, hours, url, days, message }) {
     const messageSnippet = message
       ? `const note = document.createElement('div'); note.textContent = ${JSON.stringify(message)}; banner.appendChild(note);`
       : '';
+    const hoursSnippet =
+      hours > 0
+        ? `const header = document.createElement('div');
+           header.textContent = 'Suggested hours to log: ${hours.toFixed(2)}';
+           banner.appendChild(header);
+           const list = document.createElement('ul');
+           const breakdown = ${JSON.stringify(days || [])};
+           breakdown.forEach(([day, hrs]) => {
+             const li = document.createElement('li');
+             li.textContent = \`${day}: ${hrs.toFixed(2)}\`;
+             list.appendChild(li);
+           });
+           banner.appendChild(list);`
+        : '';
     const script = `
       const banner = document.createElement('div');
       banner.style.position = 'fixed';
@@ -41,17 +55,7 @@ function openWorkItemWindow({ id, hours, url, days, message }) {
       banner.style.background = '#fffae6';
       banner.style.padding = '10px';
       banner.style.textAlign = 'center';
-      const header = document.createElement('div');
-      header.textContent = 'Suggested hours to log: ${hours.toFixed(2)}';
-      banner.appendChild(header);
-      const list = document.createElement('ul');
-      const breakdown = ${JSON.stringify(days || {})};
-      Object.entries(breakdown).forEach(([day, hrs]) => {
-        const li = document.createElement('li');
-        li.textContent = \`\${day}: \${hrs.toFixed(2)}\`;
-        list.appendChild(li);
-      });
-      banner.appendChild(list);
+      ${hoursSnippet}
       ${messageSnippet}
       document.body.appendChild(banner);
       document.body.style.marginTop = (banner.offsetHeight + 10) + 'px';


### PR DESCRIPTION
## Summary
- expose DevOps tree problems in the Work Items panel and when opening items
- only show hours banner when submitting time and display days in order
- include DevOps issues in submit-session messages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531eb0b22083238e09c56de4626836