### PR TITLE
Simplify notes with header todos

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Settings from './components/Settings';
 import YearHint from './components/YearHint';
 import Notes from './components/Notes';
 import PatrakLogo from './components/PatrakLogo';
+import TodoBar from './components/TodoBar';
 import useWorkBlocks from './hooks/useWorkBlocks';
 import useSettings from './hooks/useSettings';
 import useAdoItems from './hooks/useAdoItems';
@@ -415,7 +416,14 @@ function App() {
             No time logged today. Don't forget to log your work!
           </div>
         )}
-        <PatrakLogo />
+        <div className="flex items-start justify-between">
+          <PatrakLogo />
+          <TodoBar
+            todos={todos}
+            onToggleTodo={toggleTodo}
+            onDeleteTodo={deleteTodo}
+          />
+        </div>
         <div className="mb-2 flex items-center space-x-2">
           <button className="week-nav-button" onClick={prevWeek}>
             ◀ Prev
@@ -457,10 +465,7 @@ function App() {
           onAdd={addNote}
           onDelete={deleteNote}
           onToggleStar={toggleNoteStar}
-          todos={todos}
           onAddTodo={addTodo}
-          onToggleTodo={toggleTodo}
-          onDeleteTodo={deleteTodo}
           areas={usedAreas}
           areaAliases={areaAliases}
           setAreaAliases={setAreaAliases}

--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -8,13 +8,9 @@ export default function Notes({
   areas = [],
   areaAliases = {},
   setAreaAliases,
-  todos = [],
   onAddTodo,
-  onToggleTodo,
-  onDeleteTodo,
 }) {
   const [value, setValue] = useState('');
-  const [todoValue, setTodoValue] = useState('');
   const [tab, setTab] = useState('notes');
 
   const add = () => {
@@ -25,13 +21,6 @@ export default function Notes({
     }
   };
 
-  const addTodo = () => {
-    const text = todoValue.trim();
-    if (text) {
-      onAddTodo && onAddTodo(text);
-      setTodoValue('');
-    }
-  };
 
   const updateAlias = (area, value) => {
     if (!setAreaAliases) return;
@@ -53,14 +42,6 @@ export default function Notes({
           onClick={() => setTab('notes')}
         >
           Notes
-        </button>
-        <button
-          className={`px-2 py-1 text-xs ${
-            tab === 'todos' ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-700'
-          }`}
-          onClick={() => setTab('todos')}
-        >
-          Todos
         </button>
         <button
           className={`px-2 py-1 text-xs ${
@@ -105,6 +86,15 @@ export default function Notes({
                 >
                   {n.starred ? '★' : '☆'}
                 </button>
+                {onAddTodo && (
+                  <button
+                    className="mr-1 text-green-600"
+                    onClick={() => onAddTodo(n.text)}
+                    title="Add to Todos"
+                  >
+                    ✔
+                  </button>
+                )}
                 <span className="truncate mr-1">{n.text}</span>
                 <button
                   className="ml-auto text-red-600 text-xs"
@@ -115,44 +105,6 @@ export default function Notes({
               </div>
             ))}
           </div>
-        </>
-      )}
-      {tab === 'todos' && (
-        <>
-          <div className="flex mb-2">
-            <input
-              type="text"
-              value={todoValue}
-              onChange={(e) => setTodoValue(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && addTodo()}
-              className="border flex-grow px-1 text-sm"
-            />
-            <button
-              className="ml-2 px-2 py-1 bg-blue-500 text-white text-xs"
-              onClick={addTodo}
-            >
-              Add
-            </button>
-          </div>
-          <ul className="flex flex-col gap-1 overflow-y-auto max-h-40 text-xs">
-            {todos.map((t) => (
-              <li key={t.id} className="flex items-center">
-                <input
-                  type="checkbox"
-                  className="mr-1"
-                  checked={t.done}
-                  onChange={() => onToggleTodo && onToggleTodo(t.id)}
-                />
-                <span className={`flex-grow truncate ${t.done ? 'line-through text-gray-500' : ''}`}>{t.text}</span>
-                <button
-                  className="ml-2 text-red-600 text-xs"
-                  onClick={() => onDeleteTodo && onDeleteTodo(t.id)}
-                >
-                  x
-                </button>
-              </li>
-            ))}
-          </ul>
         </>
       )}
       {tab === 'areas' && (

--- a/src/components/TodoBar.jsx
+++ b/src/components/TodoBar.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export default function TodoBar({ todos = [], onToggleTodo, onDeleteTodo }) {
+  if (!todos.length) return null;
+  return (
+    <div className="flex flex-wrap gap-1 ml-4">
+      {todos.map((t) => (
+        <div
+          key={t.id}
+          className="flex items-center bg-yellow-100 dark:bg-gray-700 text-xs px-2 py-1 rounded-full"
+        >
+          <input
+            type="checkbox"
+            className="mr-1"
+            checked={t.done}
+            onChange={() => onToggleTodo && onToggleTodo(t.id)}
+          />
+          <span className={`truncate ${t.done ? 'line-through text-gray-500' : ''}`}>{t.text}</span>
+          <button
+            className="ml-1 text-red-600 text-xs"
+            onClick={() => onDeleteTodo && onDeleteTodo(t.id)}
+          >
+            x
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- remove the Todo tab from the notes component
- allow converting notes into todo items
- display active todos next to the Patrak logo using new `TodoBar` component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685323f6d8108323b82a446554656ca9