### PR TITLE
Enable note drag for todos

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 3. Drags on calendar to create a shell block.
 4. System suggests work items; user confirms or drags a task manually.
 5. User can click a task to auto-link it to selected time block.
-6. Notes appear as draggable comment pills that can be dropped into work blocks.
-   Star a note to keep it available after dropping.
+6. Notes appear as draggable comment pills that can be dropped into work blocks
+   or onto the todo bar. Star a note to keep it available after dropping.
 
 ### 4.2 Review & Submit
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,6 +74,11 @@ function App() {
   const deleteTodo = (id) =>
     setTodos((prev) => prev.filter((t) => t.id !== id));
 
+  const handleTodoDrop = (note) => {
+    addTodo(note.text);
+    if (!note.starred) deleteNote(note.id);
+  };
+
   const handleNoteDrop = (itemId, note) => {
     setItemNotes((prev) => {
       const list = prev[itemId] ? [...prev[itemId], note.text] : [note.text];
@@ -422,6 +427,7 @@ function App() {
             todos={todos}
             onToggleTodo={toggleTodo}
             onDeleteTodo={deleteTodo}
+            onNoteDrop={handleTodoDrop}
           />
         </div>
         <div className="mb-2 flex items-center space-x-2">
@@ -465,7 +471,6 @@ function App() {
           onAdd={addNote}
           onDelete={deleteNote}
           onToggleStar={toggleNoteStar}
-          onAddTodo={addTodo}
           areas={usedAreas}
           areaAliases={areaAliases}
           setAreaAliases={setAreaAliases}

--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -86,15 +86,6 @@ export default function Notes({
                 >
                   {n.starred ? '★' : '☆'}
                 </button>
-                {onAddTodo && (
-                  <button
-                    className="mr-1 text-green-600"
-                    onClick={() => onAddTodo(n.text)}
-                    title="Add to Todos"
-                  >
-                    ✔
-                  </button>
-                )}
                 <span className="truncate mr-1">{n.text}</span>
                 <button
                   className="ml-auto text-red-600 text-xs"

--- a/src/components/TodoBar.jsx
+++ b/src/components/TodoBar.jsx
@@ -1,9 +1,34 @@
 import React from 'react';
 
-export default function TodoBar({ todos = [], onToggleTodo, onDeleteTodo }) {
-  if (!todos.length) return null;
+export default function TodoBar({
+  todos = [],
+  onToggleTodo,
+  onDeleteTodo,
+  onNoteDrop,
+}) {
+  const allowDrop = (e) => {
+    if (e.dataTransfer.types.includes('application/x-note')) {
+      e.preventDefault();
+    }
+  };
+
+  const handleDrop = (e) => {
+    const raw = e.dataTransfer.getData('application/x-note');
+    if (!raw) return;
+    e.preventDefault();
+    const note = JSON.parse(raw);
+    onNoteDrop && onNoteDrop(note);
+  };
+
   return (
-    <div className="flex flex-wrap gap-1 ml-4">
+    <div
+      className="flex flex-wrap gap-1 ml-4"
+      onDragOver={allowDrop}
+      onDrop={handleDrop}
+    >
+      {todos.length === 0 && (
+        <div className="text-xs text-gray-500">Drop notes here</div>
+      )}
       {todos.map((t) => (
         <div
           key={t.id}


### PR DESCRIPTION
## Summary
- allow dropping notes on TodoBar to create todos
- remove add-to-todo button from Notes
- process note drops in App
- update usage docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685327ffd8fc8323be61423a10556133