### PR TITLE
Enable creating todos by right-clicking notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 4. System suggests work items; user confirms or drags a task manually.
 5. User can click a task to auto-link it to selected time block.
 6. Notes appear as draggable comment pills that can be dropped into work blocks
-   or onto the todo bar. Star a note to keep it available after dropping.
+   or onto the todo bar. Right-click a note to instantly turn it into a task.
+   Star a note to keep it available after dropping.
 
 ### 4.2 Review & Submit
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -471,6 +471,7 @@ function App() {
           onAdd={addNote}
           onDelete={deleteNote}
           onToggleStar={toggleNoteStar}
+          onAddTodo={addTodo}
           areas={usedAreas}
           areaAliases={areaAliases}
           setAreaAliases={setAreaAliases}

--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -9,17 +9,17 @@ export default function Notes({
   areaAliases = {},
   setAreaAliases,
   onAddTodo,
-}) {
+  }) {
   const [value, setValue] = useState('');
   const [tab, setTab] = useState('notes');
 
   const add = () => {
-    const text = value.trim();
-    if (text) {
-      onAdd(text);
-      setValue('');
-    }
-  };
+      const text = value.trim();
+      if (text) {
+        onAdd(text);
+        setValue('');
+      }
+    };
 
 
   const updateAlias = (area, value) => {
@@ -30,6 +30,13 @@ export default function Notes({
     } else {
       setAreaAliases({ ...areaAliases, [area]: value });
     }
+  };
+
+  const convertToTodo = (e, note) => {
+    if (!onAddTodo) return;
+    e.preventDefault();
+    onAddTodo(note.text);
+    if (!note.starred) onDelete(note.id);
   };
 
   return (
@@ -78,6 +85,8 @@ export default function Notes({
                 onDragStart={(e) =>
                   e.dataTransfer.setData('application/x-note', JSON.stringify(n))
                 }
+                onContextMenu={(e) => convertToTodo(e, n)}
+                title="Right click to create task"
               >
                 <button
                   className="mr-1 text-yellow-500"


### PR DESCRIPTION
## Summary
- support converting a note to a todo via right click
- wire Notes component to App's todo handler
- document the new interaction in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532e89b19c83238b94f61c9938b323