### PR TITLE
Fix script quoting bug

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -40,7 +40,7 @@ function openWorkItemWindow({ id, hours, url, days, message }) {
            const breakdown = ${JSON.stringify(days || [])};
            breakdown.forEach(([day, hrs]) => {
              const li = document.createElement('li');
-             li.textContent = \`${day}: ${hrs.toFixed(2)}\`;
+             li.textContent = \`\${day}: \${hrs.toFixed(2)}\`;
              list.appendChild(li);
            });
            banner.appendChild(list);`


### PR DESCRIPTION
## Summary
- escape template expressions in `openWorkItemWindow` script

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558482da9c832391e9422279d3cd1b