### PR TITLE
Fix area summary uses task area

### DIFF
--- a/__tests__/summary.test.js
+++ b/__tests__/summary.test.js
@@ -24,3 +24,22 @@ test('handles missing item', () => {
   const summary = summarizeByArea(blocks, items, date);
   expect(summary.Unassigned).toBeCloseTo(1);
 });
+
+test('prefers task area over item area', () => {
+  const blocks = [
+    {
+      start: '2023-01-01T09:00:00.000Z',
+      end: '2023-01-01T10:00:00.000Z',
+      taskId: '1',
+      itemId: '2',
+    },
+  ];
+  const items = [
+    { id: '1', area: 'AAA' },
+    { id: '2', area: 'BBB' },
+  ];
+  const date = new Date('2023-01-01T00:00:00.000Z');
+  const summary = summarizeByArea(blocks, items, date);
+  expect(summary.AAA).toBeCloseTo(1);
+  expect(summary.BBB).toBeUndefined();
+});

--- a/src/utils/summary.js
+++ b/src/utils/summary.js
@@ -6,8 +6,9 @@ export function summarizeByArea(blocks, items, dayDate) {
     if (start.toDateString() !== dateStr) continue;
     const end = new Date(b.end);
     const hrs = (end - start) / (1000 * 60 * 60);
-    const itemId = b.itemId || b.taskId;
-    const item = items?.find((i) => i.id === itemId);
+    const taskItem = b.taskId ? items?.find((i) => i.id === b.taskId) : null;
+    const displayItem = b.itemId ? items?.find((i) => i.id === b.itemId) : null;
+    const item = taskItem || displayItem;
     const area = item?.area || 'Unassigned';
     summary[area] = (summary[area] || 0) + hrs;
   }


### PR DESCRIPTION
## Summary
- correct area summary to use the task's area path when available
- test area summary when both task and item IDs exist

## Testing
- `npx jest --silent` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b0145c17c8323a6ee7c64f6029351