### PR TITLE
Improve minimap timeline and navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -486,6 +486,7 @@ function App() {
             blocks={blocks}
             settings={settings}
             items={items}
+            onWeekClick={(d) => setWeekStart(d)}
           />
         </div>
         <Calendar


### PR DESCRIPTION
## Summary
- tweak YearHint to show a sliding 12‑month view with current week at 75%
- allow clicking the minimap to jump weeks
- wire up new handler in `App.jsx`

## Testing
- `npm install` *(fails: network access blocked)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7132986883239ff9afb42d867b49