### PR TITLE
Add method to fetch specific work items

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Additionally, by making ADO updates a prerequisite for seamless time logging, th
 * Work items are cached locally; refresh only fetches updates since the last sync
 * Write time logs to tasks, bugs, and transversal activities (PATCH work item updates with time + comment)
 * Read-only enforcement on already-submitted blocks
+* `getWorkItemsByIds(ids)` helper fetches a specific list of items by ID
+* Settings allow listing work item IDs per project; listed projects fetch only those items
 
 ### 3.5 Sync & Review
 

--- a/__tests__/adoByIds.test.js
+++ b/__tests__/adoByIds.test.js
@@ -1,0 +1,19 @@
+const AdoService = require('../src/services/adoService.js').default;
+
+test('getWorkItemsByIds returns fetched items', async () => {
+  const svc = new AdoService('org', 'tok');
+  jest.spyOn(svc, '_fetchItems').mockResolvedValue([
+    { id: '1', parentId: null, dependencies: [] },
+  ]);
+  jest.spyOn(svc, '_fetchRelations').mockResolvedValue({});
+
+  const items = await svc.getWorkItemsByIds(['1']);
+  expect(items).toHaveLength(1);
+  expect(items[0].id).toBe('1');
+});
+
+test('getWorkItemsByIds ignores empty input', async () => {
+  const svc = new AdoService('org', 'tok');
+  const result = await svc.getWorkItemsByIds([]);
+  expect(result).toEqual([]);
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -157,7 +157,8 @@ function App() {
       azureTags,
       azureArea,
       azureIteration,
-      settings.enableDevOpsReview
+      settings.enableDevOpsReview,
+      settings.projectItems
     );
     let since = null;
     if (!full) {
@@ -441,7 +442,8 @@ function App() {
     settings.azureTags,
     settings.azureArea,
     settings.azureIteration,
-    settings.enableDevOpsReview
+    settings.enableDevOpsReview,
+    settings.projectItems
   );
   const treeProblems = settings.enableDevOpsReview
     ? reviewService.findTreeProblems(items)

--- a/src/components/DevOpsReview.jsx
+++ b/src/components/DevOpsReview.jsx
@@ -9,7 +9,8 @@ export default function DevOpsReview({ items = [], settings }) {
     settings.azureTags,
     settings.azureArea,
     settings.azureIteration,
-    true
+    true,
+    settings.projectItems
   );
 
   const treeProblems = service.findTreeProblems(items);

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -219,6 +219,10 @@ export default function Settings({ settings, setSettings, onExport, onImport }) 
                                 ...temp.projectColors,
                                 [name]: newColor,
                               },
+                              projectItems: {
+                                ...temp.projectItems,
+                                [name]: [],
+                              },
                             });
                             setNewProject('');
                             setNewColor('#cccccc');
@@ -246,6 +250,24 @@ export default function Settings({ settings, setSettings, onExport, onImport }) 
                             }
                             className="mx-1"
                           />
+                          <input
+                            type="text"
+                            placeholder="IDs"
+                            value={(temp.projectItems[p] || []).join(', ')}
+                            onChange={(e) =>
+                              setTemp({
+                                ...temp,
+                                projectItems: {
+                                  ...temp.projectItems,
+                                  [p]: e.target.value
+                                    .split(',')
+                                    .map((id) => id.trim())
+                                    .filter((id) => id),
+                                },
+                              })
+                            }
+                            className="border flex-grow px-1 text-xs mx-1"
+                          />
                           <button
                             className="text-xs text-red-600"
                             onClick={() =>
@@ -254,6 +276,9 @@ export default function Settings({ settings, setSettings, onExport, onImport }) 
                                 azureProjects: temp.azureProjects.filter((_, i) => i !== idx),
                                 projectColors: Object.fromEntries(
                                   Object.entries(temp.projectColors).filter(([key]) => key !== p)
+                                ),
+                                projectItems: Object.fromEntries(
+                                  Object.entries(temp.projectItems).filter(([key]) => key !== p)
                                 ),
                               })
                             }

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -14,6 +14,7 @@ const defaultSettings = {
   azurePat: '',
   azureProjects: [],
   projectColors: {},
+  projectItems: {},
   azureTags: [],
   azureArea: '',
   azureIteration: '',


### PR DESCRIPTION
## Summary
- add optional `projectItems` map to settings
- allow listing IDs per project in settings UI
- fetch only the listed items for those projects
- document new setting in README

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7828ec088323aec767b15fdd2965