### PR TITLE
Add option to skip parent retrieval

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -158,7 +158,8 @@ function App() {
       azureArea,
       azureIteration,
       settings.enableDevOpsReview,
-      settings.projectItems
+      settings.projectItems,
+      settings.fetchParents
     );
     let since = null;
     if (!full) {
@@ -443,7 +444,8 @@ function App() {
     settings.azureArea,
     settings.azureIteration,
     settings.enableDevOpsReview,
-    settings.projectItems
+    settings.projectItems,
+    settings.fetchParents
   );
   const treeProblems = settings.enableDevOpsReview
     ? reviewService.findTreeProblems(items)

--- a/src/components/DevOpsReview.jsx
+++ b/src/components/DevOpsReview.jsx
@@ -10,7 +10,8 @@ export default function DevOpsReview({ items = [], settings }) {
     settings.azureArea,
     settings.azureIteration,
     true,
-    settings.projectItems
+    settings.projectItems,
+    settings.fetchParents
   );
 
   const treeProblems = service.findTreeProblems(items);

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -15,6 +15,7 @@ const defaultSettings = {
   azureProjects: [],
   projectColors: {},
   projectItems: {},
+  fetchParents: true,
   azureTags: [],
   azureArea: '',
   azureIteration: '',


### PR DESCRIPTION
## Summary
- add `fetchParents` flag in `AdoService`
- pass new setting from app and review components
- store new flag in settings hook

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7f965dbc83239de4078b521be828